### PR TITLE
Add did key and did web examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ W3C functions under a [code of conduct](https://www.w3.org/Consortium/cepc/).
 
 See the [Test Server](./packages/did-core-test-server).
 
+```
+npm i
+npm run generate-report
+```
+
 ## DID Working Group Repositories
 
 - [W3C Decentralized Identifier Specification v1.0](https://github.com/w3c/did-core)

--- a/index.html
+++ b/index.html
@@ -108,16 +108,16 @@ if (!suiteConfig) {
   suiteConfig = require("./defaultSuiteConfig.json");
 }
 
-describe("test-suite-a", () => {
-  it("suite config should have correct name", async () => {
+describe("test-suite-a", () =&gt; {
+  it("suite config should have correct name", async () =&gt; {
     expect(suiteConfig.name).toBe("test-suite-a");
   });
 
-  it("a should be 1", async () => {
+  it("a should be 1", async () =&gt; {
     expect(suiteConfig.a).toBe(1);
   });
 
-  it("b should be 2", async () => {
+  it("b should be 2", async () =&gt; {
     expect(suiteConfig.b).toBe(2);
   });
 });
@@ -148,7 +148,7 @@ describe("test-suite-a", () => {
         >
 
         <pre class="example" title="Example test of statement">
-it('The DID method name MUST be an ASCII lowercase string.', () => {
+it('The DID method name MUST be an ASCII lowercase string.', () =&gt; {
   const method = did.split(':')[1];
   expect(utils.isAsciiString(method)).toBe(true);
   expect(method.toLowerCase()).toBe(method);
@@ -327,268 +327,609 @@ it('The DID method name MUST be an ASCII lowercase string.', () => {
           here</a
         >
       </p>
+      <p id="did-spec-report-date" class="note">
+        These test results were last generated
+        <span> Saturday, January 23, 2021 4:42 PM </span>
+      </p>
+
       <pre
-        id="did-spec-suite-report"
+        id="did-spec-suite-input"
         class="example"
-        title="did-spec latest report results"
+        title="did-spec latest input report"
       >
-      [
-      {
-        "suite": "did-spec",
-        "testResults": [
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "did-syntax",
-              "did:example:123"
-            ],
-            "title": "MUST be a valid URL.",
-            "status": "passed"
+[
+  {
+    "name": "did-spec",
+    "didMethods": {
+      "did:key": {
+        "supportedContentTypes": [
+          "application/did+json",
+          "application/did+ld+json"
+        ],
+        "dids": [
+          "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+        ],
+        "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB": {
+          "application/did+json": {
+            "didDocument": {
+              "@context": [
+                "https://www.w3.org/ns/did/v1",
+                {
+                  "@base": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+                }
+              ],
+              "id": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+              "verificationMethod": [
+                {
+                  "id": "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+                  "type": "JsonWebKey2020",
+                  "controller": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+                  "publicKeyJwk": {
+                    "crv": "Ed25519",
+                    "x": "LKacPea7et-QMhcyS02ZjsTHEVadsCj_XNnfFJYbwHo",
+                    "kty": "OKP"
+                  }
+                },
+                {
+                  "id": "#z6LSh8yKFPF2bLnD9mHQZMJL6zQQZsowYUeUaDd39rMLHBBx",
+                  "type": "JsonWebKey2020",
+                  "controller": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+                  "publicKeyJwk": {
+                    "kty": "OKP",
+                    "crv": "X25519",
+                    "x": "USe317eZOgxr3-neAHaJ8fZ056kb7miDxZvb5ymFKVM"
+                  }
+                }
+              ],
+              "authentication": [
+                "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              ],
+              "assertionMethod": [
+                "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              ],
+              "capabilityInvocation": [
+                "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              ],
+              "capabilityDelegation": [
+                "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              ],
+              "keyAgreement": [
+                "#z6LSh8yKFPF2bLnD9mHQZMJL6zQQZsowYUeUaDd39rMLHBBx"
+              ]
+            },
+            "didDocumentMetaData": {
+              "content-type": "application/did+json"
+            },
+            "didResolutionMetaData": {}
           },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "did-syntax",
-              "did:example:123"
-            ],
-            "title": "The URI scheme MUST be \"did:\"",
-            "status": "passed"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "did-syntax",
-              "did:example:123"
-            ],
-            "title": "The DID method name MUST be an ASCII lowercase string.",
-            "status": "passed"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "did-syntax",
-              "did:example:123"
-            ],
-            "title": "The DID method name MUST NOT be empty.",
-            "status": "passed"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "did-parameters",
-              "hl"
-            ],
-            "title": "The associated value MUST be an ASCII string.",
-            "status": "passed"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "did-parameters",
-              "service"
-            ],
-            "title": "The associated value MUST be an ASCII string.",
-            "status": "passed"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "did-parameters",
-              "relative-ref"
-            ],
-            "title": "The associated value MUST be an ASCII string.",
-            "status": "passed"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "did-parameters",
-              "relative-ref"
-            ],
-            "title": "MUST use percent-encoding for certain characters as specified in RFC3986 Section 2.1.",
-            "status": "passed"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "did-parameters",
-              "version-id"
-            ],
-            "title": "The associated value MUST be an ASCII string.",
-            "status": "passed"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "did-parameters",
-              "version-time"
-            ],
-            "title": "The associated value MUST be an ASCII string.",
-            "status": "passed"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "resolution",
-              "did:example:123",
-              "application/did+json",
-              "id"
-            ],
-            "title": "MUST be the same as the resolved ID",
-            "status": "passed"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "resolution",
-              "did:example:123",
-              "application/did+json",
-              "canonicalId"
-            ],
-            "title": "MUST be of the same DID Method as the resolved ID",
-            "status": "passed"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "resolution",
-              "did:example:123",
-              "application/did+json",
-              "canonicalId"
-            ],
-            "title": "MUST be recognized as the primary ID reference",
-            "status": "passed"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "resolution",
-              "did:example:123",
-              "application/did+json",
-              "canonicalId"
-            ],
-            "title": "If the resolved ID differs from canonicalId, it must be recognized as an equivalent reference",
-            "status": "passed"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "resolution",
-              "did:example:123",
-              "application/did+json",
-              "equivalentId"
-            ],
-            "title": "MUST be of the same DID Method as the resolved ID",
-            "status": "passed"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "resolution",
-              "did:example:123",
-              "application/did+json",
-              "equivalentId"
-            ],
-            "title": "Its values must be recognized as equivalent ID references.",
-            "status": "passed"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "resolution",
-              "did:example:123",
-              "application/did+json",
-              "equivalentId"
-            ],
-            "title": "Resolved ID must be recognized as the primary reference, absent a specified canonicalId",
-            "status": "passed"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "resolution",
-              "did:example:123",
-              "application/did+ld+json",
-              "id"
-            ],
-            "title": "MUST be the same as the resolved ID",
-            "status": "passed"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "did-json-production"
-            ],
-            "title": "Numeric values representable as IEEE754 MUST be represented as a Number type.",
-            "status": "todo"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "did-json-production"
-            ],
-            "title": "Boolean values MUST be represented as a Boolean literal.",
-            "status": "todo"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "did-json-production"
-            ],
-            "title": "Sequence value MUST be represented as an Array type.",
-            "status": "todo"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "did-json-production"
-            ],
-            "title": "Unordered sets of values MUST be represented as an Array type.",
-            "status": "todo"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "did-json-production"
-            ],
-            "title": "Sets of properties MUST be represented as an Object type.",
-            "status": "todo"
-          },
-          {
-            "ancestors": [
-              "did-spec",
-              "did:example",
-              "did-json-production"
-            ],
-            "title": "Empty values MUST be represented as a null literal.",
-            "status": "todo"
+          "application/did+ld+json": {
+            "didDocument": {
+              "@context": [
+                "https://www.w3.org/ns/did/v1",
+                {
+                  "@base": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+                }
+              ],
+              "id": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+              "verificationMethod": [
+                {
+                  "id": "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+                  "type": "Ed25519VerificationKey2018",
+                  "controller": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+                  "publicKeyBase58": "41JHobRgR1SiXc8SEKbizupfXvSz7dQTRqdByQWRUU5o"
+                },
+                {
+                  "id": "#z6LSh8yKFPF2bLnD9mHQZMJL6zQQZsowYUeUaDd39rMLHBBx",
+                  "type": "X25519KeyAgreementKey2019",
+                  "controller": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+                  "publicKeyBase58": "6To9j5SAVt4U4Nue2hnNnQBvijGpqsUKhEuMfPhoZoRC"
+                }
+              ],
+              "authentication": [
+                "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              ],
+              "assertionMethod": [
+                "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              ],
+              "capabilityInvocation": [
+                "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              ],
+              "capabilityDelegation": [
+                "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              ],
+              "keyAgreement": [
+                "#z6LSh8yKFPF2bLnD9mHQZMJL6zQQZsowYUeUaDd39rMLHBBx"
+              ]
+            },
+            "didDocumentMetaData": {
+              "content-type": "application/did+ld+json"
+            },
+            "didResolutionMetaData": {}
           }
-        ]
+        }
+      },
+      "did:web": {
+        "supportedContentTypes": [
+          "application/did+json",
+          "application/did+ld+json"
+        ],
+        "dids": [
+          "did:web:did.actor:mike"
+        ],
+        "did:web:did.actor:mike": {
+          "application/did+json": {
+            "didDocument": {
+              "@context": [
+                "https://www.w3.org/ns/did/v1",
+                {
+                  "@base": "did:web:did.actor:mike",
+                  "rating": "https://schema.org/Rating",
+                  "publicAccess": "https://schema.org/publicAccess"
+                }
+              ],
+              "id": "did:web:did.actor:mike",
+              "rating": 4.5,
+              "publicAccess": true,
+              "additionalType": null,
+              "verificationMethod": [
+                {
+                  "id": "#g1",
+                  "controller": "did:web:did.actor:mike",
+                  "type": "JsonWebKey2020",
+                  "publicKeyJwk": {
+                    "kty": "EC",
+                    "crv": "BLS12381_G1",
+                    "x": "hxF12gtsn9ju4-kJq2-nUjZQKVVWpcBAYX5VHnUZMDilClZsGuOaDjlXS8pFE1GG"
+                  }
+                },
+                {
+                  "id": "#g2",
+                  "controller": "did:web:did.actor:mike",
+                  "type": "JsonWebKey2020",
+                  "publicKeyJwk": {
+                    "kty": "EC",
+                    "crv": "BLS12381_G2",
+                    "x": "l4MeBsn_OGa2OEDtHeHdq0TBC8sYh6QwoI7QsNtZk9oAru1OnGClaAPlMbvvs73EABDB6GjjzybbOHarkBmP6pon8H1VuMna0nkEYihZi8OodgdbwReDiDvWzZuXXMl-"
+                  }
+                }
+              ],
+              "authentication": [
+                "did:web:did.actor:mike#g1",
+                "did:web:did.actor:mike#g2"
+              ],
+              "assertionMethod": [
+                "did:web:did.actor:mike#g1",
+                "did:web:did.actor:mike#g2"
+              ]
+            }
+          },
+          "application/did+ld+json": {
+            "didDocument": {
+              "@context": [
+                "https://www.w3.org/ns/did/v1",
+                {
+                  "@base": "did:web:did.actor:mike",
+                  "rating": "https://schema.org/Rating",
+                  "publicAccess": "https://schema.org/publicAccess"
+                }
+              ],
+              "id": "did:web:did.actor:mike",
+              "rating": 4.5,
+              "publicAccess": true,
+              "additionalType": null,
+              "verificationMethod": [
+                {
+                  "id": "#g1",
+                  "controller": "did:web:did.actor:mike",
+                  "type": "JsonWebKey2020",
+                  "publicKeyJwk": {
+                    "kty": "EC",
+                    "crv": "BLS12381_G1",
+                    "x": "hxF12gtsn9ju4-kJq2-nUjZQKVVWpcBAYX5VHnUZMDilClZsGuOaDjlXS8pFE1GG"
+                  }
+                },
+                {
+                  "id": "#g2",
+                  "controller": "did:web:did.actor:mike",
+                  "type": "JsonWebKey2020",
+                  "publicKeyJwk": {
+                    "kty": "EC",
+                    "crv": "BLS12381_G2",
+                    "x": "l4MeBsn_OGa2OEDtHeHdq0TBC8sYh6QwoI7QsNtZk9oAru1OnGClaAPlMbvvs73EABDB6GjjzybbOHarkBmP6pon8H1VuMna0nkEYihZi8OodgdbwReDiDvWzZuXXMl-"
+                  }
+                }
+              ],
+              "authentication": [
+                "did:web:did.actor:mike#g1",
+                "did:web:did.actor:mike#g2"
+              ],
+              "assertionMethod": [
+                "did:web:did.actor:mike#g1",
+                "did:web:did.actor:mike#g2"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+]
+      </pre>
+
+      <pre
+        id="did-spec-suite-output"
+        class="example"
+        title="did-spec latest output report"
+      >
+[
+  {
+    "suite": "did-spec",
+    "testResults": [
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-syntax",
+          "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+        ],
+        "title": "MUST be a valid URL.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-syntax",
+          "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+        ],
+        "title": "The URI scheme MUST be \"did:\"",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-syntax",
+          "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+        ],
+        "title": "The DID method name MUST be an ASCII lowercase string.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-syntax",
+          "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+        ],
+        "title": "The DID method name MUST NOT be empty.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "resolution",
+          "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+          "application/did+json",
+          "id"
+        ],
+        "title": "MUST be the same as the resolved ID",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "resolution",
+          "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+          "application/did+ld+json",
+          "id"
+        ],
+        "title": "MUST be the same as the resolved ID",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-json-production"
+        ],
+        "title": "Numeric values representable as IEEE754 MUST be represented as a Number type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-json-production"
+        ],
+        "title": "Boolean values MUST be represented as a Boolean literal.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-json-production"
+        ],
+        "title": "Sequence value MUST be represented as an Array type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-json-production"
+        ],
+        "title": "Unordered sets of values MUST be represented as an Array type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-json-production"
+        ],
+        "title": "Sets of properties MUST be represented as an Object type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-json-production"
+        ],
+        "title": "Empty values MUST be represented as a null literal.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-ld-json-production"
+        ],
+        "title": "The value of @context MUST be exactly one of these values.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-ld-json-production"
+        ],
+        "title": "Numeric values representable as IEEE754 MUST be represented as a Number type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-ld-json-production"
+        ],
+        "title": "Boolean values MUST be represented as a Boolean literal.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-ld-json-production"
+        ],
+        "title": "Sequence value MUST be represented as an Array type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-ld-json-production"
+        ],
+        "title": "Unordered sets of values MUST be represented as an Array type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-ld-json-production"
+        ],
+        "title": "Sets of properties MUST be represented as an Object type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-ld-json-production"
+        ],
+        "title": "Empty values MUST be represented as a null literal.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-syntax",
+          "did:web:did.actor:mike"
+        ],
+        "title": "MUST be a valid URL.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-syntax",
+          "did:web:did.actor:mike"
+        ],
+        "title": "The URI scheme MUST be \"did:\"",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-syntax",
+          "did:web:did.actor:mike"
+        ],
+        "title": "The DID method name MUST be an ASCII lowercase string.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-syntax",
+          "did:web:did.actor:mike"
+        ],
+        "title": "The DID method name MUST NOT be empty.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "resolution",
+          "did:web:did.actor:mike",
+          "application/did+json",
+          "id"
+        ],
+        "title": "MUST be the same as the resolved ID",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "resolution",
+          "did:web:did.actor:mike",
+          "application/did+ld+json",
+          "id"
+        ],
+        "title": "MUST be the same as the resolved ID",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-json-production"
+        ],
+        "title": "Numeric values representable as IEEE754 MUST be represented as a Number type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-json-production"
+        ],
+        "title": "Boolean values MUST be represented as a Boolean literal.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-json-production"
+        ],
+        "title": "Sequence value MUST be represented as an Array type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-json-production"
+        ],
+        "title": "Unordered sets of values MUST be represented as an Array type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-json-production"
+        ],
+        "title": "Sets of properties MUST be represented as an Object type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-json-production"
+        ],
+        "title": "Empty values MUST be represented as a null literal.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-ld-json-production"
+        ],
+        "title": "The value of @context MUST be exactly one of these values.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-ld-json-production"
+        ],
+        "title": "Numeric values representable as IEEE754 MUST be represented as a Number type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-ld-json-production"
+        ],
+        "title": "Boolean values MUST be represented as a Boolean literal.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-ld-json-production"
+        ],
+        "title": "Sequence value MUST be represented as an Array type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-ld-json-production"
+        ],
+        "title": "Unordered sets of values MUST be represented as an Array type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-ld-json-production"
+        ],
+        "title": "Sets of properties MUST be represented as an Object type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-ld-json-production"
+        ],
+        "title": "Empty values MUST be represented as a null literal.",
+        "status": "passed"
       }
     ]
+  }
+]
       </pre>
     </section>
 
@@ -625,168 +966,169 @@ it('The DID method name MUST be an ASCII lowercase string.', () => {
     </section>
 
     <section id="conformance"></section>
-  </body>
 
-  <script>
-    const testSuiteManagerEndpoint =
-      window.location.hostname === 'localhost'
-        ? 'http://localhost:8080/test-suite-manager/generate-report'
-        : 'https://vc.transmute.world/test-suite-manager/generate-report';
+    <script>
+      const testSuiteManagerEndpoint =
+        window.location.hostname === 'localhost'
+          ? 'http://localhost:8080/test-suite-manager/generate-report'
+          : 'https://vc.transmute.world/test-suite-manager/generate-report';
 
-    function b64DecodeUnicode(str) {
-      // Going backwards: from bytestream, to percent-encoding, to original string.
-      return decodeURIComponent(
-        atob(str)
-          .split('')
-          .map(function (c) {
-            return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
-          })
-          .join('')
-      );
-    }
+      function b64DecodeUnicode(str) {
+        // Going backwards: from bytestream, to percent-encoding, to original string.
+        return decodeURIComponent(
+          atob(str)
+            .split('')
+            .map(function (c) {
+              return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+            })
+            .join('')
+        );
+      }
 
-    var editor = ace.edit('report-suites-input');
-    editor.setTheme('ace/theme/github');
-    editor.session.setMode('ace/mode/json');
-    editor.setValue(
-      JSON.stringify(
-        [
-          {
-            name: 'did-spec',
-            didMethods: {
-              'did:range14': {
-                supportedContentTypes: ['application/did+json'],
-                dids: ['did:range14:123'],
-                'did:range14:123': {
-                  'application/did+json': {
-                    didDocument: {
-                      '@context': ['https://www.w3.org/ns/did/v1'],
-                      id: 'did:range14:123',
+      var editor = ace.edit('report-suites-input');
+      editor.setTheme('ace/theme/github');
+      editor.session.setMode('ace/mode/json');
+      editor.setValue(
+        JSON.stringify(
+          [
+            {
+              name: 'did-spec',
+              didMethods: {
+                'did:range14': {
+                  supportedContentTypes: ['application/did+json'],
+                  dids: ['did:range14:123'],
+                  'did:range14:123': {
+                    'application/did+json': {
+                      didDocument: {
+                        '@context': ['https://www.w3.org/ns/did/v1'],
+                        id: 'did:range14:123',
+                      },
+                      didDocumentMetaData: {
+                        'content-type': 'application/did+json',
+                      },
+                      didResolutionMetaData: {},
                     },
-                    didDocumentMetaData: {
-                      'content-type': 'application/did+json',
-                    },
-                    didResolutionMetaData: {},
                   },
                 },
               },
             },
-          },
-        ],
-        null,
-        2
-      )
-    );
+          ],
+          null,
+          2
+        )
+      );
 
-    var term = new Terminal({
-      convertEol: true,
-    });
-    term.open(document.getElementById('terminal'));
+      var term = new Terminal({
+        convertEol: true,
+      });
+      term.open(document.getElementById('terminal'));
 
-    var generateReport = async () => {
-      try {
-        const res = await fetch(testSuiteManagerEndpoint, {
-          headers: {
-            'Content-Type': 'application/json',
-            Accept: 'application/ld+json',
-          },
-          method: 'post',
-          body: editor.getValue(),
+      var generateReport = async () => {
+        try {
+          const res = await fetch(testSuiteManagerEndpoint, {
+            headers: {
+              'Content-Type': 'application/json',
+              Accept: 'application/ld+json',
+            },
+            method: 'post',
+            body: editor.getValue(),
+          });
+
+          const responseBody = await res.json();
+
+          let encodedReport = responseBody.suitesReportTerminal;
+
+          renderReportResults(
+            'on-demand-report-results',
+            responseBody.suitesReportJson
+          );
+
+          term.reset();
+          term.write(b64DecodeUnicode(encodedReport));
+          alert('succeeded');
+        } catch (e) {
+          alert('failed');
+        }
+      };
+
+      const resultToEmoji = (test) => {
+        return test === 'passed' ? `✅` : `❌`;
+      };
+
+      const renderReportResults = (target, results) => {
+        let flattenMethodResults = {};
+
+        results[0].testResults.forEach((tr) => {
+          let ancestorsWithoutMethod = tr.ancestors.filter((a) => {
+            return !a.includes(tr.ancestors[1]);
+          });
+
+          let testAncestorsWithoutMethod = ancestorsWithoutMethod.join(' > ');
+          let testKey = `${testAncestorsWithoutMethod} > ${tr.title}`;
+          let didMethodTestResult = {
+            status: tr.status,
+            method: tr.ancestors[1],
+          };
+
+          if (!flattenMethodResults[testKey]) {
+            flattenMethodResults[testKey] = {
+              ancestorsWithoutMethod: ancestorsWithoutMethod.splice(1),
+              title: tr.title,
+              didMethods: [didMethodTestResult],
+            };
+          } else {
+            flattenMethodResults[testKey].didMethods.push(didMethodTestResult);
+          }
         });
 
-        const responseBody = await res.json();
-
-        let encodedReport = responseBody.suitesReportTerminal;
-
-        renderReportResults(
-          'on-demand-report-results',
-          responseBody.suitesReportJson
+        const resultsSorted = Object.values(flattenMethodResults).sort(
+          (a, b) => {
+            return a.ancestorsWithoutMethod.join(' > ') >
+              b.ancestorsWithoutMethod.join(' > ')
+              ? 1
+              : -1;
+          }
         );
 
-        term.reset();
-        term.write(b64DecodeUnicode(encodedReport));
-        alert('succeeded');
-      } catch (e) {
-        alert('failed');
-      }
-    };
-
-    const resultToEmoji = (test) => {
-      return test === 'passed' ? `✅` : `❌`;
-    };
-
-    const renderReportResults = (target, results) => {
-      let flattenMethodResults = {};
-
-      results[0].testResults.forEach((tr) => {
-        let ancestorsWithoutMethod = tr.ancestors.filter((a) => {
-          return !a.includes(tr.ancestors[1]);
+        // this makes thing hierarchical again
+        let resultsBySection = {};
+        let root = resultsBySection;
+        resultsSorted.forEach((tr) => {
+          root = resultsBySection;
+          if (tr.ancestorsWithoutMethod.length > 1) {
+            let tail;
+            for (let i = 0; i < tr.ancestorsWithoutMethod.length; i++) {
+              let sectionName = tr.ancestorsWithoutMethod[i];
+              if (!root[sectionName]) {
+                root[sectionName] = {};
+              } else {
+                root[sectionName] = {
+                  ...root[sectionName],
+                };
+              }
+              tail = root;
+              root = root[sectionName];
+            }
+            Object.keys(tail).forEach((tailKey) => {
+              tail[tailKey] = {
+                ...tail[tailKey],
+                [tr.title]: tr.didMethods,
+                isLeaf: true,
+              };
+            });
+          } else {
+            root[tr.ancestorsWithoutMethod[0]] = {
+              ...root[tr.ancestorsWithoutMethod[0]],
+              isLeaf: true,
+              [tr.title]: tr.didMethods,
+            };
+          }
         });
 
-        let testAncestorsWithoutMethod = ancestorsWithoutMethod.join(' > ');
-        let testKey = `${testAncestorsWithoutMethod} > ${tr.title}`;
-        let didMethodTestResult = {
-          status: tr.status,
-          method: tr.ancestors[1],
-        };
-
-        if (!flattenMethodResults[testKey]) {
-          flattenMethodResults[testKey] = {
-            ancestorsWithoutMethod: ancestorsWithoutMethod.splice(1),
-            title: tr.title,
-            didMethods: [didMethodTestResult],
-          };
-        } else {
-          flattenMethodResults[testKey].didMethods.push(didMethodTestResult);
-        }
-      });
-
-      const resultsSorted = Object.values(flattenMethodResults).sort((a, b) => {
-        return a.ancestorsWithoutMethod.join(' > ') >
-          b.ancestorsWithoutMethod.join(' > ')
-          ? 1
-          : -1;
-      });
-
-      // this makes thing hierarchical again
-      let resultsBySection = {};
-      let root = resultsBySection;
-      resultsSorted.forEach((tr) => {
-        root = resultsBySection;
-        if (tr.ancestorsWithoutMethod.length > 1) {
-          let tail;
-          for (let i = 0; i < tr.ancestorsWithoutMethod.length; i++) {
-            let sectionName = tr.ancestorsWithoutMethod[i];
-            if (!root[sectionName]) {
-              root[sectionName] = {};
-            } else {
-              root[sectionName] = {
-                ...root[sectionName],
-              };
-            }
-            tail = root;
-            root = root[sectionName];
-          }
-          Object.keys(tail).forEach((tailKey) => {
-            tail[tailKey] = {
-              ...tail[tailKey],
-              [tr.title]: tr.didMethods,
-              isLeaf: true,
-            };
-          });
-        } else {
-          root[tr.ancestorsWithoutMethod[0]] = {
-            ...root[tr.ancestorsWithoutMethod[0]],
-            isLeaf: true,
-            [tr.title]: tr.didMethods,
-          };
-        }
-      });
-
-      const recursiveRenderSection = (section, level) => {
-        let result = '';
-        if (section && !section.isLeaf && Object.keys(section).length) {
-          result = `
+        const recursiveRenderSection = (section, level) => {
+          let result = '';
+          if (section && !section.isLeaf && Object.keys(section).length) {
+            result = `
 
         ${Object.keys(section)
           .map((key) => {
@@ -802,28 +1144,28 @@ ${subSection}
           .join('\n')}
 
                   `;
-        } else {
-          result = Object.keys(section)
-            .map((statement) => {
-              if (statement === 'isLeaf') {
-                return '';
-              }
-              const count = section[statement]
-                .map((test) => {
-                  return {
-                    status: test.status === 'passed' ? 'passed' : 'failed',
-                  };
-                })
-                .reduce((tally, test) => {
-                  if (!tally[test.status]) {
-                    tally[test.status] = 1;
-                  } else {
-                    tally[test.status] = tally[test.status] + 1;
-                  }
-                  return tally;
-                }, {});
+          } else {
+            result = Object.keys(section)
+              .map((statement) => {
+                if (statement === 'isLeaf') {
+                  return '';
+                }
+                const count = section[statement]
+                  .map((test) => {
+                    return {
+                      status: test.status === 'passed' ? 'passed' : 'failed',
+                    };
+                  })
+                  .reduce((tally, test) => {
+                    if (!tally[test.status]) {
+                      tally[test.status] = 1;
+                    } else {
+                      tally[test.status] = tally[test.status] + 1;
+                    }
+                    return tally;
+                  }, {});
 
-              const resultTable = `
+                const resultTable = `
 <table class="simple" >
 <tbody>
 <tr>
@@ -846,29 +1188,33 @@ ${count.passed ? resultToEmoji('passed') + ` (${count.passed})` : ''}
 </table>
 `;
 
-              return `
+                return `
 <div>
 <p>${statement}</p>
 ${resultTable}
 </div>
 `;
-            })
-            .join('\n');
-        }
+              })
+              .join('\n');
+          }
 
-        return result;
+          return result;
+        };
+
+        let level = 3;
+        const testResultReport = recursiveRenderSection(
+          resultsBySection,
+          level
+        );
+        document.getElementById(target).innerHTML =
+          document.getElementById(target).innerHTML + testResultReport;
       };
 
-      let level = 3;
-      const testResultReport = recursiveRenderSection(resultsBySection, level);
-      document.getElementById(target).innerHTML =
-        document.getElementById(target).innerHTML + testResultReport;
-    };
+      const lastDidSpecReport = JSON.parse(
+        document.getElementById('did-spec-suite-output').innerHTML
+      );
 
-    const lastDidSpecReport = JSON.parse(
-      document.getElementById('did-spec-suite-report').innerHTML
-    );
-
-    renderReportResults('report-results', lastDidSpecReport);
-  </script>
+      renderReportResults('report-results', lastDidSpecReport);
+    </script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lint": "lerna run lint --stream",
     "test": "lerna run test --stream",
     "docker:up": "docker-compose up",
-    "docker:build": "docker-compose up --build"
+    "docker:build": "docker-compose up --build",
+    "generate-report": "lerna run generate-report --stream "
   },
   "devDependencies": {
     "lerna": "^3.22.1"
@@ -34,5 +35,9 @@
     "semi": true,
     "singleQuote": true,
     "trailingComma": "es5"
+  },
+  "dependencies": {
+    "cheerio": "^1.0.0-rc.5",
+    "moment": "^2.29.1"
   }
 }

--- a/packages/did-core-test-server/generate-latest-respec-data.js
+++ b/packages/did-core-test-server/generate-latest-respec-data.js
@@ -1,10 +1,52 @@
 const fs = require('fs');
+const path = require('path');
+const cheerio = require('cheerio');
+const moment = require('moment');
 const getReportResults = require('./services/getReportResults');
 const suitesInput = require('./suites/did-spec/default.json');
 
+const respecPath = path.resolve(__dirname, '../../index.html');
+
+const updateRespec = (suitesInput, suitesReportJson) => {
+  const spec = fs.readFileSync(respecPath).toString();
+  const $ = cheerio.load(spec);
+
+  $('#did-spec-suite-input').replaceWith(
+    `<pre
+        id="did-spec-suite-input"
+        class="example"
+        title="did-spec latest input report"
+      >
+${JSON.stringify(suitesInput, null, 2)}
+      </pre>`
+  );
+
+  $('#did-spec-suite-output').replaceWith(
+    `<pre
+        id="did-spec-suite-output"
+        class="example"
+        title="did-spec latest output report"
+      >
+${JSON.stringify(suitesReportJson, null, 2)}
+      </pre>`
+  );
+
+  $('#did-spec-report-date').replaceWith(
+    `<p id="did-spec-report-date" class="note">
+These test results were last generated 
+<span>
+${moment().format('LLLL')}
+</span>
+      </p>`
+  );
+
+  const updatedSpec = $.html();
+  fs.writeFileSync(respecPath, updatedSpec);
+};
+
 (async () => {
   const { suitesReportJson } = await getReportResults(suitesInput);
-
+  updateRespec(suitesInput, suitesReportJson);
   fs.writeFileSync(
     `../../test-vectors/did-spec.latest.json`,
     JSON.stringify(suitesReportJson, null, 2)

--- a/packages/did-core-test-server/suites/did-spec/default.json
+++ b/packages/did-core-test-server/suites/did-spec/default.json
@@ -2,53 +2,59 @@
   {
     "name": "did-spec",
     "didMethods": {
-      "did:example": {
+      "did:key": {
         "supportedContentTypes": [
           "application/did+json",
           "application/did+ld+json"
         ],
-        "dids": ["did:example:123"],
-        "didParameters": {
-          "hl": "did:example:123?hl=zQmWvQxTqbG2Z9HPJgG57jjwR154cKhbtJenbyYTWkjgF3e",
-          "service": "did:example:123?service=agent&relativeRef=%2Fpath%2Fto%2Fresource",
-          "relative-ref": "did:example:123?service=agent&relativeRef=%2Fpath%2Fto%2Fresource",
-          "version-id": "did:example:123?version-id=0.1.0",
-          "version-time": "did:example:123?version-time=1601151242"
-        },
-        "did:example:123": {
+        "dids": ["did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"],
+        "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB": {
           "application/did+json": {
             "didDocument": {
-              "@context": ["https://www.w3.org/ns/did/v1"],
-              "id": "did:example:123",
-              "canonicalId": "did:example:one-two-three",
-              "equivalentId": "did:example:one-two-three",
+              "@context": [
+                "https://www.w3.org/ns/did/v1",
+                {
+                  "@base": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+                }
+              ],
+              "id": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
               "verificationMethod": [
                 {
-                  "id": "#key-0",
+                  "id": "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
                   "type": "JsonWebKey2020",
-                  "controller": "did:example:123",
+                  "controller": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
                   "publicKeyJwk": {
-                    "kty": "OKP",
                     "crv": "Ed25519",
-                    "x": "VDXDwuGKVq91zxU6q7__jLDUq8_C5cuxECgd-1feFTE"
+                    "x": "LKacPea7et-QMhcyS02ZjsTHEVadsCj_XNnfFJYbwHo",
+                    "kty": "OKP"
                   }
                 },
                 {
-                  "id": "#key-1",
+                  "id": "#z6LSh8yKFPF2bLnD9mHQZMJL6zQQZsowYUeUaDd39rMLHBBx",
                   "type": "JsonWebKey2020",
-                  "controller": "did:example:123",
+                  "controller": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
                   "publicKeyJwk": {
                     "kty": "OKP",
                     "crv": "X25519",
-                    "x": "3kY9jl1by7pLzgJktUH-e9H6fihdVUb00-sTzkfmIl8"
+                    "x": "USe317eZOgxr3-neAHaJ8fZ056kb7miDxZvb5ymFKVM"
                   }
                 }
               ],
-              "authentication": ["#key-0"],
-              "assertionMethod": ["#key-0"],
-              "capabilityInvocation": ["#key-0"],
-              "capabilityDelegation": ["#key-0"],
-              "keyAgreement": ["#key-1"]
+              "authentication": [
+                "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              ],
+              "assertionMethod": [
+                "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              ],
+              "capabilityInvocation": [
+                "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              ],
+              "capabilityDelegation": [
+                "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              ],
+              "keyAgreement": [
+                "#z6LSh8yKFPF2bLnD9mHQZMJL6zQQZsowYUeUaDd39rMLHBBx"
+              ]
             },
             "didDocumentMetaData": {
               "content-type": "application/did+json"
@@ -57,47 +63,147 @@
           },
           "application/did+ld+json": {
             "didDocument": {
-              "@context": ["https://www.w3.org/ns/did/v1"],
-              "id": "did:example:123",
-              "verificationMethod": [
+              "@context": [
+                "https://www.w3.org/ns/did/v1",
                 {
-                  "id": "#key-0",
-                  "type": "Ed25519VerificationKey2018",
-                  "controller": "did:example:123",
-                  "publicKeyBase58": "6fioC1zcDPyPEL19pXRS2E4iJ46zH7xP6uSgAaPdwDrx"
-                },
-                {
-                  "id": "#key-1",
-                  "type": "X25519KeyAgreementKey2019",
-                  "controller": "did:example:123",
-                  "publicKeyBase58": "FxfdY3DCQxVZddKGAtSjZdFW9bCCW7oRwZn1NFJ2Tbg2"
+                  "@base": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
                 }
               ],
-              "authentication": ["#key-0"],
-              "assertionMethod": ["#key-0"],
-              "capabilityInvocation": ["#key-0"],
-              "capabilityDelegation": ["#key-0"],
-              "keyAgreement": ["#key-1"]
+              "id": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+              "verificationMethod": [
+                {
+                  "id": "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+                  "type": "Ed25519VerificationKey2018",
+                  "controller": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+                  "publicKeyBase58": "41JHobRgR1SiXc8SEKbizupfXvSz7dQTRqdByQWRUU5o"
+                },
+                {
+                  "id": "#z6LSh8yKFPF2bLnD9mHQZMJL6zQQZsowYUeUaDd39rMLHBBx",
+                  "type": "X25519KeyAgreementKey2019",
+                  "controller": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+                  "publicKeyBase58": "6To9j5SAVt4U4Nue2hnNnQBvijGpqsUKhEuMfPhoZoRC"
+                }
+              ],
+              "authentication": [
+                "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              ],
+              "assertionMethod": [
+                "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              ],
+              "capabilityInvocation": [
+                "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              ],
+              "capabilityDelegation": [
+                "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              ],
+              "keyAgreement": [
+                "#z6LSh8yKFPF2bLnD9mHQZMJL6zQQZsowYUeUaDd39rMLHBBx"
+              ]
             },
             "didDocumentMetaData": {
               "content-type": "application/did+ld+json"
             },
             "didResolutionMetaData": {}
           }
-        },
-        "did:Cool": {
-          "supportedContentTypes": ["application/did+cool+json"],
-          "dids": ["did:Cool:123"],
-          "did:Cool:123": {
-            "application/did+cool+json": {
-              "didDocument": {
-                "id": "did:Cool:123",
-                "forbidden__proto__": { "vulnerable": "cool?" }
-              },
-              "didDocumentMetaData": {
-                "content-type": "application/did+cool+json"
-              },
-              "didResolutionMetaData": {}
+        }
+      },
+      "did:web": {
+        "supportedContentTypes": [
+          "application/did+json",
+          "application/did+ld+json"
+        ],
+        "dids": ["did:web:did.actor:mike"],
+        "did:web:did.actor:mike": {
+          "application/did+json": {
+            "didDocument": {
+              "@context": [
+                "https://www.w3.org/ns/did/v1",
+                {
+                  "@base": "did:web:did.actor:mike",
+                  "rating": "https://schema.org/Rating",
+                  "publicAccess": "https://schema.org/publicAccess"
+                }
+              ],
+              "id": "did:web:did.actor:mike",
+              "rating": 4.5,
+              "publicAccess": true,
+              "additionalType": null,
+              "verificationMethod": [
+                {
+                  "id": "#g1",
+                  "controller": "did:web:did.actor:mike",
+                  "type": "JsonWebKey2020",
+                  "publicKeyJwk": {
+                    "kty": "EC",
+                    "crv": "BLS12381_G1",
+                    "x": "hxF12gtsn9ju4-kJq2-nUjZQKVVWpcBAYX5VHnUZMDilClZsGuOaDjlXS8pFE1GG"
+                  }
+                },
+                {
+                  "id": "#g2",
+                  "controller": "did:web:did.actor:mike",
+                  "type": "JsonWebKey2020",
+                  "publicKeyJwk": {
+                    "kty": "EC",
+                    "crv": "BLS12381_G2",
+                    "x": "l4MeBsn_OGa2OEDtHeHdq0TBC8sYh6QwoI7QsNtZk9oAru1OnGClaAPlMbvvs73EABDB6GjjzybbOHarkBmP6pon8H1VuMna0nkEYihZi8OodgdbwReDiDvWzZuXXMl-"
+                  }
+                }
+              ],
+              "authentication": [
+                "did:web:did.actor:mike#g1",
+                "did:web:did.actor:mike#g2"
+              ],
+              "assertionMethod": [
+                "did:web:did.actor:mike#g1",
+                "did:web:did.actor:mike#g2"
+              ]
+            }
+          },
+          "application/did+ld+json": {
+            "didDocument": {
+              "@context": [
+                "https://www.w3.org/ns/did/v1",
+                {
+                  "@base": "did:web:did.actor:mike",
+                  "rating": "https://schema.org/Rating",
+                  "publicAccess": "https://schema.org/publicAccess"
+                }
+              ],
+              "id": "did:web:did.actor:mike",
+              "rating": 4.5,
+              "publicAccess": true,
+              "additionalType": null,
+              "verificationMethod": [
+                {
+                  "id": "#g1",
+                  "controller": "did:web:did.actor:mike",
+                  "type": "JsonWebKey2020",
+                  "publicKeyJwk": {
+                    "kty": "EC",
+                    "crv": "BLS12381_G1",
+                    "x": "hxF12gtsn9ju4-kJq2-nUjZQKVVWpcBAYX5VHnUZMDilClZsGuOaDjlXS8pFE1GG"
+                  }
+                },
+                {
+                  "id": "#g2",
+                  "controller": "did:web:did.actor:mike",
+                  "type": "JsonWebKey2020",
+                  "publicKeyJwk": {
+                    "kty": "EC",
+                    "crv": "BLS12381_G2",
+                    "x": "l4MeBsn_OGa2OEDtHeHdq0TBC8sYh6QwoI7QsNtZk9oAru1OnGClaAPlMbvvs73EABDB6GjjzybbOHarkBmP6pon8H1VuMna0nkEYihZi8OodgdbwReDiDvWzZuXXMl-"
+                  }
+                }
+              ],
+              "authentication": [
+                "did:web:did.actor:mike#g1",
+                "did:web:did.actor:mike#g2"
+              ],
+              "assertionMethod": [
+                "did:web:did.actor:mike#g1",
+                "did:web:did.actor:mike#g2"
+              ]
             }
           }
         }

--- a/packages/did-core-test-server/suites/did-spec/did-ld-json-production.js
+++ b/packages/did-core-test-server/suites/did-spec/did-ld-json-production.js
@@ -1,9 +1,22 @@
-const didJsonProductionTests = (suiteConfig) => {
-  if (suiteConfig.supportedContentTypes.includes('application/did+json')) {
-    describe('did-json-production', () => {
+const didLdJsonProductionTests = (suiteConfig) => {
+  if (suiteConfig.supportedContentTypes.includes('application/did+ld+json')) {
+    describe('did-ld-json-production', () => {
+      it('The value of @context MUST be exactly one of these values.', () => {
+        const [did] = suiteConfig.dids;
+        const { didDocument } = suiteConfig[did]['application/did+ld+json'];
+        if (typeof didDocument['@context'] === 'string') {
+          expect(didDocument['@context']).toBe('https://www.w3.org/ns/did/v1');
+        }
+        if (Array.isArray(didDocument['@context'])) {
+          expect(didDocument['@context'][0]).toBe(
+            'https://www.w3.org/ns/did/v1'
+          );
+        }
+      });
+
       it('Numeric values representable as IEEE754 MUST be represented as a Number type.', () => {
         const [did] = suiteConfig.dids;
-        const { didDocument } = suiteConfig[did]['application/did+json'];
+        const { didDocument } = suiteConfig[did]['application/did+ld+json'];
         const knownNumericProperties = ['rating'];
         for (const [key, value] of Object.entries(didDocument)) {
           if (knownNumericProperties.includes(key)) {
@@ -14,7 +27,7 @@ const didJsonProductionTests = (suiteConfig) => {
 
       it('Boolean values MUST be represented as a Boolean literal.', () => {
         const [did] = suiteConfig.dids;
-        const { didDocument } = suiteConfig[did]['application/did+json'];
+        const { didDocument } = suiteConfig[did]['application/did+ld+json'];
         const knownPublicProperties = ['publicAccess'];
         for (const [key, value] of Object.entries(didDocument)) {
           if (knownPublicProperties.includes(key)) {
@@ -24,7 +37,7 @@ const didJsonProductionTests = (suiteConfig) => {
       });
       it('Sequence value MUST be represented as an Array type.', () => {
         const [did] = suiteConfig.dids;
-        const { didDocument } = suiteConfig[did]['application/did+json'];
+        const { didDocument } = suiteConfig[did]['application/did+ld+json'];
 
         if (didDocument.verificationMethod) {
           expect(Array.isArray(didDocument.verificationMethod)).toBe(true);
@@ -51,7 +64,7 @@ const didJsonProductionTests = (suiteConfig) => {
       });
       it('Unordered sets of values MUST be represented as an Array type.', () => {
         const [did] = suiteConfig.dids;
-        const { didDocument } = suiteConfig[did]['application/did+json'];
+        const { didDocument } = suiteConfig[did]['application/did+ld+json'];
 
         if (didDocument.verificationMethod) {
           expect(Array.isArray(didDocument.verificationMethod)).toBe(true);
@@ -78,12 +91,12 @@ const didJsonProductionTests = (suiteConfig) => {
       });
       it('Sets of properties MUST be represented as an Object type.', () => {
         const [did] = suiteConfig.dids;
-        const { didDocument } = suiteConfig[did]['application/did+json'];
+        const { didDocument } = suiteConfig[did]['application/did+ld+json'];
         expect(typeof didDocument).toBe('object');
       });
       it('Empty values MUST be represented as a null literal.', () => {
         const [did] = suiteConfig.dids;
-        const { didDocument } = suiteConfig[did]['application/did+json'];
+        const { didDocument } = suiteConfig[did]['application/did+ld+json'];
         const knownNullProperties = ['additionalType'];
         for (const [key, value] of Object.entries(didDocument)) {
           if (knownNullProperties.includes(key)) {
@@ -95,4 +108,4 @@ const didJsonProductionTests = (suiteConfig) => {
   }
 };
 
-module.exports = { didJsonProductionTests };
+module.exports = { didLdJsonProductionTests };

--- a/packages/did-core-test-server/suites/did-spec/did.spec.js
+++ b/packages/did-core-test-server/suites/did-spec/did.spec.js
@@ -14,6 +14,9 @@ describe('did-spec', () => {
       require('./did-json-production').didJsonProductionTests(
         didMethodSuiteConfig
       );
+      require('./did-ld-json-production').didLdJsonProductionTests(
+        didMethodSuiteConfig
+      );
     });
   });
 });

--- a/packages/did-core-test-server/suites/methods/README.md
+++ b/packages/did-core-test-server/suites/methods/README.md
@@ -1,0 +1,4 @@
+This folder is for testing methods in isolation.
+
+In order to show conformance,
+methods must copy their suite configuration details into the `did-spec/defaultSuiteConfig.json`

--- a/packages/did-core-test-server/suites/methods/did-key/defaultSuiteConfig.json
+++ b/packages/did-core-test-server/suites/methods/did-key/defaultSuiteConfig.json
@@ -1,0 +1,110 @@
+{
+  "name": "did-spec",
+  "didMethods": {
+    "did:key": {
+      "supportedContentTypes": [
+        "application/did+json",
+        "application/did+ld+json"
+      ],
+      "dids": ["did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"],
+      "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB": {
+        "application/did+json": {
+          "didDocument": {
+            "@context": [
+              "https://www.w3.org/ns/did/v1",
+              {
+                "@base": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              }
+            ],
+            "id": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+            "verificationMethod": [
+              {
+                "id": "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+                "type": "JsonWebKey2020",
+                "controller": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+                "publicKeyJwk": {
+                  "crv": "Ed25519",
+                  "x": "LKacPea7et-QMhcyS02ZjsTHEVadsCj_XNnfFJYbwHo",
+                  "kty": "OKP"
+                }
+              },
+              {
+                "id": "#z6LSh8yKFPF2bLnD9mHQZMJL6zQQZsowYUeUaDd39rMLHBBx",
+                "type": "JsonWebKey2020",
+                "controller": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+                "publicKeyJwk": {
+                  "kty": "OKP",
+                  "crv": "X25519",
+                  "x": "USe317eZOgxr3-neAHaJ8fZ056kb7miDxZvb5ymFKVM"
+                }
+              }
+            ],
+            "authentication": [
+              "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+            ],
+            "assertionMethod": [
+              "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+            ],
+            "capabilityInvocation": [
+              "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+            ],
+            "capabilityDelegation": [
+              "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+            ],
+            "keyAgreement": [
+              "#z6LSh8yKFPF2bLnD9mHQZMJL6zQQZsowYUeUaDd39rMLHBBx"
+            ]
+          },
+          "didDocumentMetaData": {
+            "content-type": "application/did+json"
+          },
+          "didResolutionMetaData": {}
+        },
+        "application/did+ld+json": {
+          "didDocument": {
+            "@context": [
+              "https://www.w3.org/ns/did/v1",
+              {
+                "@base": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+              }
+            ],
+            "id": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+            "verificationMethod": [
+              {
+                "id": "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+                "type": "Ed25519VerificationKey2018",
+                "controller": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+                "publicKeyBase58": "41JHobRgR1SiXc8SEKbizupfXvSz7dQTRqdByQWRUU5o"
+              },
+              {
+                "id": "#z6LSh8yKFPF2bLnD9mHQZMJL6zQQZsowYUeUaDd39rMLHBBx",
+                "type": "X25519KeyAgreementKey2019",
+                "controller": "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
+                "publicKeyBase58": "6To9j5SAVt4U4Nue2hnNnQBvijGpqsUKhEuMfPhoZoRC"
+              }
+            ],
+            "authentication": [
+              "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+            ],
+            "assertionMethod": [
+              "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+            ],
+            "capabilityInvocation": [
+              "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+            ],
+            "capabilityDelegation": [
+              "#z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
+            ],
+            "keyAgreement": [
+              "#z6LSh8yKFPF2bLnD9mHQZMJL6zQQZsowYUeUaDd39rMLHBBx"
+            ]
+          },
+          "didDocumentMetaData": {
+            "content-type": "application/did+ld+json"
+          },
+          "didResolutionMetaData": {}
+        }
+      }
+    }
+  }
+}

--- a/packages/did-core-test-server/suites/methods/did-key/did-key.spec.js
+++ b/packages/did-core-test-server/suites/methods/did-key/did-key.spec.js
@@ -1,0 +1,27 @@
+let { suiteConfig } = global;
+
+if (!suiteConfig) {
+  // did-key only for testing purposes
+  suiteConfig = require('./defaultSuiteConfig.json');
+}
+
+describe('did-spec', () => {
+  Object.keys(suiteConfig.didMethods).forEach((didMethod) => {
+    describe(didMethod, () => {
+      const didMethodSuiteConfig = suiteConfig.didMethods[didMethod];
+      require('../../did-spec/did-syntax').didSyntaxTests(didMethodSuiteConfig);
+      require('../../did-spec/did-parameters').didParametersTests(
+        didMethodSuiteConfig
+      );
+      require('../../did-spec/did-resolution').didResolutionTests(
+        didMethodSuiteConfig
+      );
+      require('../../did-spec/did-json-production').didJsonProductionTests(
+        didMethodSuiteConfig
+      );
+      require('../../did-spec/did-ld-json-production').didLdJsonProductionTests(
+        didMethodSuiteConfig
+      );
+    });
+  });
+});

--- a/packages/did-core-test-server/suites/methods/did-web/defaultSuiteConfig.json
+++ b/packages/did-core-test-server/suites/methods/did-web/defaultSuiteConfig.json
@@ -1,0 +1,106 @@
+{
+  "name": "did-spec",
+  "didMethods": {
+    "did:web": {
+      "supportedContentTypes": [
+        "application/did+json",
+        "application/did+ld+json"
+      ],
+      "dids": ["did:web:did.actor:mike"],
+      "did:web:did.actor:mike": {
+        "application/did+json": {
+          "didDocument": {
+            "@context": [
+              "https://www.w3.org/ns/did/v1",
+              {
+                "@base": "did:web:did.actor:mike",
+                "rating": "https://schema.org/Rating",
+                "publicAccess": "https://schema.org/publicAccess"
+              }
+            ],
+            "id": "did:web:did.actor:mike",
+            "rating": 4.5,
+            "publicAccess": true,
+            "additionalType": null,
+            "verificationMethod": [
+              {
+                "id": "#g1",
+                "controller": "did:web:did.actor:mike",
+                "type": "JsonWebKey2020",
+                "publicKeyJwk": {
+                  "kty": "EC",
+                  "crv": "BLS12381_G1",
+                  "x": "hxF12gtsn9ju4-kJq2-nUjZQKVVWpcBAYX5VHnUZMDilClZsGuOaDjlXS8pFE1GG"
+                }
+              },
+              {
+                "id": "#g2",
+                "controller": "did:web:did.actor:mike",
+                "type": "JsonWebKey2020",
+                "publicKeyJwk": {
+                  "kty": "EC",
+                  "crv": "BLS12381_G2",
+                  "x": "l4MeBsn_OGa2OEDtHeHdq0TBC8sYh6QwoI7QsNtZk9oAru1OnGClaAPlMbvvs73EABDB6GjjzybbOHarkBmP6pon8H1VuMna0nkEYihZi8OodgdbwReDiDvWzZuXXMl-"
+                }
+              }
+            ],
+            "authentication": [
+              "did:web:did.actor:mike#g1",
+              "did:web:did.actor:mike#g2"
+            ],
+            "assertionMethod": [
+              "did:web:did.actor:mike#g1",
+              "did:web:did.actor:mike#g2"
+            ]
+          }
+        },
+        "application/did+ld+json": {
+          "didDocument": {
+            "@context": [
+              "https://www.w3.org/ns/did/v1",
+              {
+                "@base": "did:web:did.actor:mike",
+                "rating": "https://schema.org/Rating",
+                "publicAccess": "https://schema.org/publicAccess"
+              }
+            ],
+            "id": "did:web:did.actor:mike",
+            "rating": 4.5,
+            "publicAccess": true,
+            "additionalType": null,
+            "verificationMethod": [
+              {
+                "id": "#g1",
+                "controller": "did:web:did.actor:mike",
+                "type": "JsonWebKey2020",
+                "publicKeyJwk": {
+                  "kty": "EC",
+                  "crv": "BLS12381_G1",
+                  "x": "hxF12gtsn9ju4-kJq2-nUjZQKVVWpcBAYX5VHnUZMDilClZsGuOaDjlXS8pFE1GG"
+                }
+              },
+              {
+                "id": "#g2",
+                "controller": "did:web:did.actor:mike",
+                "type": "JsonWebKey2020",
+                "publicKeyJwk": {
+                  "kty": "EC",
+                  "crv": "BLS12381_G2",
+                  "x": "l4MeBsn_OGa2OEDtHeHdq0TBC8sYh6QwoI7QsNtZk9oAru1OnGClaAPlMbvvs73EABDB6GjjzybbOHarkBmP6pon8H1VuMna0nkEYihZi8OodgdbwReDiDvWzZuXXMl-"
+                }
+              }
+            ],
+            "authentication": [
+              "did:web:did.actor:mike#g1",
+              "did:web:did.actor:mike#g2"
+            ],
+            "assertionMethod": [
+              "did:web:did.actor:mike#g1",
+              "did:web:did.actor:mike#g2"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/did-core-test-server/suites/methods/did-web/did-web.spec.js
+++ b/packages/did-core-test-server/suites/methods/did-web/did-web.spec.js
@@ -1,0 +1,27 @@
+let { suiteConfig } = global;
+
+if (!suiteConfig) {
+  // did-key only for testing purposes
+  suiteConfig = require('./defaultSuiteConfig.json');
+}
+
+describe('did-spec', () => {
+  Object.keys(suiteConfig.didMethods).forEach((didMethod) => {
+    describe(didMethod, () => {
+      const didMethodSuiteConfig = suiteConfig.didMethods[didMethod];
+      require('../../did-spec/did-syntax').didSyntaxTests(didMethodSuiteConfig);
+      require('../../did-spec/did-parameters').didParametersTests(
+        didMethodSuiteConfig
+      );
+      require('../../did-spec/did-resolution').didResolutionTests(
+        didMethodSuiteConfig
+      );
+      require('../../did-spec/did-json-production').didJsonProductionTests(
+        didMethodSuiteConfig
+      );
+      require('../../did-spec/did-ld-json-production').didLdJsonProductionTests(
+        didMethodSuiteConfig
+      );
+    });
+  });
+});

--- a/test-vectors/did-spec.latest.json
+++ b/test-vectors/did-spec.latest.json
@@ -5,9 +5,9 @@
       {
         "ancestors": [
           "did-spec",
-          "did:example",
+          "did:key",
           "did-syntax",
-          "did:example:123"
+          "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
         ],
         "title": "MUST be a valid URL.",
         "status": "passed"
@@ -15,9 +15,9 @@
       {
         "ancestors": [
           "did-spec",
-          "did:example",
+          "did:key",
           "did-syntax",
-          "did:example:123"
+          "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
         ],
         "title": "The URI scheme MUST be \"did:\"",
         "status": "passed"
@@ -25,9 +25,9 @@
       {
         "ancestors": [
           "did-spec",
-          "did:example",
+          "did:key",
           "did-syntax",
-          "did:example:123"
+          "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
         ],
         "title": "The DID method name MUST be an ASCII lowercase string.",
         "status": "passed"
@@ -35,9 +35,9 @@
       {
         "ancestors": [
           "did-spec",
-          "did:example",
+          "did:key",
           "did-syntax",
-          "did:example:123"
+          "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB"
         ],
         "title": "The DID method name MUST NOT be empty.",
         "status": "passed"
@@ -45,69 +45,9 @@
       {
         "ancestors": [
           "did-spec",
-          "did:example",
-          "did-parameters",
-          "hl"
-        ],
-        "title": "The associated value MUST be an ASCII string.",
-        "status": "passed"
-      },
-      {
-        "ancestors": [
-          "did-spec",
-          "did:example",
-          "did-parameters",
-          "service"
-        ],
-        "title": "The associated value MUST be an ASCII string.",
-        "status": "passed"
-      },
-      {
-        "ancestors": [
-          "did-spec",
-          "did:example",
-          "did-parameters",
-          "relative-ref"
-        ],
-        "title": "The associated value MUST be an ASCII string.",
-        "status": "passed"
-      },
-      {
-        "ancestors": [
-          "did-spec",
-          "did:example",
-          "did-parameters",
-          "relative-ref"
-        ],
-        "title": "MUST use percent-encoding for certain characters as specified in RFC3986 Section 2.1.",
-        "status": "passed"
-      },
-      {
-        "ancestors": [
-          "did-spec",
-          "did:example",
-          "did-parameters",
-          "version-id"
-        ],
-        "title": "The associated value MUST be an ASCII string.",
-        "status": "passed"
-      },
-      {
-        "ancestors": [
-          "did-spec",
-          "did:example",
-          "did-parameters",
-          "version-time"
-        ],
-        "title": "The associated value MUST be an ASCII string.",
-        "status": "passed"
-      },
-      {
-        "ancestors": [
-          "did-spec",
-          "did:example",
+          "did:key",
           "resolution",
-          "did:example:123",
+          "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
           "application/did+json",
           "id"
         ],
@@ -117,81 +57,9 @@
       {
         "ancestors": [
           "did-spec",
-          "did:example",
+          "did:key",
           "resolution",
-          "did:example:123",
-          "application/did+json",
-          "canonicalId"
-        ],
-        "title": "MUST be of the same DID Method as the resolved ID",
-        "status": "passed"
-      },
-      {
-        "ancestors": [
-          "did-spec",
-          "did:example",
-          "resolution",
-          "did:example:123",
-          "application/did+json",
-          "canonicalId"
-        ],
-        "title": "MUST be recognized as the primary ID reference",
-        "status": "passed"
-      },
-      {
-        "ancestors": [
-          "did-spec",
-          "did:example",
-          "resolution",
-          "did:example:123",
-          "application/did+json",
-          "canonicalId"
-        ],
-        "title": "If the resolved ID differs from canonicalId, it must be recognized as an equivalent reference",
-        "status": "passed"
-      },
-      {
-        "ancestors": [
-          "did-spec",
-          "did:example",
-          "resolution",
-          "did:example:123",
-          "application/did+json",
-          "equivalentId"
-        ],
-        "title": "MUST be of the same DID Method as the resolved ID",
-        "status": "passed"
-      },
-      {
-        "ancestors": [
-          "did-spec",
-          "did:example",
-          "resolution",
-          "did:example:123",
-          "application/did+json",
-          "equivalentId"
-        ],
-        "title": "Its values must be recognized as equivalent ID references.",
-        "status": "passed"
-      },
-      {
-        "ancestors": [
-          "did-spec",
-          "did:example",
-          "resolution",
-          "did:example:123",
-          "application/did+json",
-          "equivalentId"
-        ],
-        "title": "Resolved ID must be recognized as the primary reference, absent a specified canonicalId",
-        "status": "passed"
-      },
-      {
-        "ancestors": [
-          "did-spec",
-          "did:example",
-          "resolution",
-          "did:example:123",
+          "did:key:z6MkhTZLPqg7kYwBe6y8utZZr1NfMViqXWep7rY7ogUSPgsB",
           "application/did+ld+json",
           "id"
         ],
@@ -201,56 +69,300 @@
       {
         "ancestors": [
           "did-spec",
-          "did:example",
+          "did:key",
           "did-json-production"
         ],
         "title": "Numeric values representable as IEEE754 MUST be represented as a Number type.",
-        "status": "todo"
+        "status": "passed"
       },
       {
         "ancestors": [
           "did-spec",
-          "did:example",
+          "did:key",
           "did-json-production"
         ],
         "title": "Boolean values MUST be represented as a Boolean literal.",
-        "status": "todo"
+        "status": "passed"
       },
       {
         "ancestors": [
           "did-spec",
-          "did:example",
+          "did:key",
           "did-json-production"
         ],
         "title": "Sequence value MUST be represented as an Array type.",
-        "status": "todo"
+        "status": "passed"
       },
       {
         "ancestors": [
           "did-spec",
-          "did:example",
+          "did:key",
           "did-json-production"
         ],
         "title": "Unordered sets of values MUST be represented as an Array type.",
-        "status": "todo"
+        "status": "passed"
       },
       {
         "ancestors": [
           "did-spec",
-          "did:example",
+          "did:key",
           "did-json-production"
         ],
         "title": "Sets of properties MUST be represented as an Object type.",
-        "status": "todo"
+        "status": "passed"
       },
       {
         "ancestors": [
           "did-spec",
-          "did:example",
+          "did:key",
           "did-json-production"
         ],
         "title": "Empty values MUST be represented as a null literal.",
-        "status": "todo"
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-ld-json-production"
+        ],
+        "title": "The value of @context MUST be exactly one of these values.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-ld-json-production"
+        ],
+        "title": "Numeric values representable as IEEE754 MUST be represented as a Number type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-ld-json-production"
+        ],
+        "title": "Boolean values MUST be represented as a Boolean literal.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-ld-json-production"
+        ],
+        "title": "Sequence value MUST be represented as an Array type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-ld-json-production"
+        ],
+        "title": "Unordered sets of values MUST be represented as an Array type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-ld-json-production"
+        ],
+        "title": "Sets of properties MUST be represented as an Object type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:key",
+          "did-ld-json-production"
+        ],
+        "title": "Empty values MUST be represented as a null literal.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-syntax",
+          "did:web:did.actor:mike"
+        ],
+        "title": "MUST be a valid URL.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-syntax",
+          "did:web:did.actor:mike"
+        ],
+        "title": "The URI scheme MUST be \"did:\"",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-syntax",
+          "did:web:did.actor:mike"
+        ],
+        "title": "The DID method name MUST be an ASCII lowercase string.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-syntax",
+          "did:web:did.actor:mike"
+        ],
+        "title": "The DID method name MUST NOT be empty.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "resolution",
+          "did:web:did.actor:mike",
+          "application/did+json",
+          "id"
+        ],
+        "title": "MUST be the same as the resolved ID",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "resolution",
+          "did:web:did.actor:mike",
+          "application/did+ld+json",
+          "id"
+        ],
+        "title": "MUST be the same as the resolved ID",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-json-production"
+        ],
+        "title": "Numeric values representable as IEEE754 MUST be represented as a Number type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-json-production"
+        ],
+        "title": "Boolean values MUST be represented as a Boolean literal.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-json-production"
+        ],
+        "title": "Sequence value MUST be represented as an Array type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-json-production"
+        ],
+        "title": "Unordered sets of values MUST be represented as an Array type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-json-production"
+        ],
+        "title": "Sets of properties MUST be represented as an Object type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-json-production"
+        ],
+        "title": "Empty values MUST be represented as a null literal.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-ld-json-production"
+        ],
+        "title": "The value of @context MUST be exactly one of these values.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-ld-json-production"
+        ],
+        "title": "Numeric values representable as IEEE754 MUST be represented as a Number type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-ld-json-production"
+        ],
+        "title": "Boolean values MUST be represented as a Boolean literal.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-ld-json-production"
+        ],
+        "title": "Sequence value MUST be represented as an Array type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-ld-json-production"
+        ],
+        "title": "Unordered sets of values MUST be represented as an Array type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-ld-json-production"
+        ],
+        "title": "Sets of properties MUST be represented as an Object type.",
+        "status": "passed"
+      },
+      {
+        "ancestors": [
+          "did-spec",
+          "did:web",
+          "did-ld-json-production"
+        ],
+        "title": "Empty values MUST be represented as a null literal.",
+        "status": "passed"
       }
     ]
   }


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 23, 2021, 10:44 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fdid-test-suite%2F56fd379907847a1a69e6d5c2629759909254f4a7%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: https://rawcdn.githack.com/w3c/did-test-suite/56fd379907847a1a69e6d5c2629759909254f4a7/index.html?isPreview=true&publishDate=2021-01-23
ReSpec version: 26.0.0
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: TypeError: Cannot destructure property 'rsDocToDataURL' of '(intermediate value)' as it is undefined.
    at evaluateHTML (__puppeteer_evaluation_script__:23:13)
    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:217:19)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:106:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:208:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:87:18)
    at async Object.generate [as respec] (/u/spec-generator/generators/respec.js:13:40)
    at async /u/spec-generator/server.js:89:44

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/did-test-suite%2319.)._
</details>
