### PR TITLE
Test DID Parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -401,7 +401,7 @@ it('The DID method name MUST be an ASCII lowercase string.', () => {
               "did-spec",
               "did:example",
               "did-parameters",
-              "relative-ref"
+              "relativeRef"
             ],
             "title": "The associated value MUST be an ASCII string.",
             "status": "passed"
@@ -411,7 +411,7 @@ it('The DID method name MUST be an ASCII lowercase string.', () => {
               "did-spec",
               "did:example",
               "did-parameters",
-              "relative-ref"
+              "relativeRef"
             ],
             "title": "MUST use percent-encoding for certain characters as specified in RFC3986 Section 2.1.",
             "status": "passed"
@@ -421,7 +421,7 @@ it('The DID method name MUST be an ASCII lowercase string.', () => {
               "did-spec",
               "did:example",
               "did-parameters",
-              "version-id"
+              "versionId"
             ],
             "title": "The associated value MUST be an ASCII string.",
             "status": "passed"
@@ -431,7 +431,7 @@ it('The DID method name MUST be an ASCII lowercase string.', () => {
               "did-spec",
               "did:example",
               "did-parameters",
-              "version-time"
+              "versionTime"
             ],
             "title": "The associated value MUST be an ASCII string.",
             "status": "passed"

--- a/packages/did-core-test-server/suites/did-spec/default.json
+++ b/packages/did-core-test-server/suites/did-spec/default.json
@@ -11,9 +11,9 @@
         "didParameters": {
           "hl": "did:example:123?hl=zQmWvQxTqbG2Z9HPJgG57jjwR154cKhbtJenbyYTWkjgF3e",
           "service": "did:example:123?service=agent&relativeRef=%2Fpath%2Fto%2Fresource",
-          "relative-ref": "did:example:123?service=agent&relativeRef=%2Fpath%2Fto%2Fresource",
-          "version-id": "did:example:123?version-id=0.1.0",
-          "version-time": "did:example:123?version-time=1601151242"
+          "relativeRef": "did:example:123?service=agent&relativeRef=%2Fpath%2Fto%2Fresource",
+          "versionId": "did:example:123?versionId=0.1.0",
+          "versionTime": "did:example:123?versionTime=1601151242"
         },
         "did:example:123": {
           "application/did+json": {

--- a/packages/did-core-test-server/suites/did-spec/default.json
+++ b/packages/did-core-test-server/suites/did-spec/default.json
@@ -13,7 +13,7 @@
           "service": "did:example:123?service=agent&relativeRef=%2Fpath%2Fto%2Fresource",
           "relativeRef": "did:example:123?service=agent&relativeRef=%2Fpath%2Fto%2Fresource",
           "versionId": "did:example:123?versionId=0.1.0",
-          "versionTime": "did:example:123?versionTime=1601151242"
+          "versionTime": "did:example:123?versionTime=2020-09-26T20:14:02Z"
         },
         "did:example:123": {
           "application/did+json": {

--- a/packages/did-core-test-server/suites/did-spec/defaultSuiteConfig.json
+++ b/packages/did-core-test-server/suites/did-spec/defaultSuiteConfig.json
@@ -12,7 +12,7 @@
         "service": "did:example:123?service=agent&relativeRef=%2Fpath%2Fto%2Fresource",
         "relativeRef": "did:example:123?service=agent&relativeRef=%2Fpath%2Fto%2Fresource",
         "versionId": "did:example:123?versionId=0.1.0",
-        "versionTime": "did:example:123?versionTime=1601151242"
+        "versionTime": "did:example:123?versionTime=2020-09-26T20:14:02Z"
       },
       "did:example:123": {
         "application/did+json": {

--- a/packages/did-core-test-server/suites/did-spec/defaultSuiteConfig.json
+++ b/packages/did-core-test-server/suites/did-spec/defaultSuiteConfig.json
@@ -10,9 +10,9 @@
       "didParameters": {
         "hl": "did:example:123?hl=zQmWvQxTqbG2Z9HPJgG57jjwR154cKhbtJenbyYTWkjgF3e",
         "service": "did:example:123?service=agent&relativeRef=%2Fpath%2Fto%2Fresource",
-        "relative-ref": "did:example:123?service=agent&relativeRef=%2Fpath%2Fto%2Fresource",
-        "version-id": "did:example:123?version-id=0.1.0",
-        "version-time": "did:example:123?version-time=1601151242"
+        "relativeRef": "did:example:123?service=agent&relativeRef=%2Fpath%2Fto%2Fresource",
+        "versionId": "did:example:123?versionId=0.1.0",
+        "versionTime": "did:example:123?versionTime=1601151242"
       },
       "did:example:123": {
         "application/did+json": {

--- a/packages/did-core-test-server/suites/did-spec/did-parameters.js
+++ b/packages/did-core-test-server/suites/did-spec/did-parameters.js
@@ -14,7 +14,7 @@ const didParametersTests = (suiteConfig) => {
             expect(utils.isAsciiString(param)).toBe(true);
           });
 
-          if (didParameter === 'relative-ref') {
+          if (didParameter === 'relativeRef') {
             it('MUST use percent-encoding for certain characters as specified in RFC3986 Section 2.1.', async () => {
               const didUrl = suiteConfig.didParameters[didParameter];
               const param = utils.getQueryParamValueFromDidUri(

--- a/packages/did-core-test-server/suites/did-spec/did-parameters.js
+++ b/packages/did-core-test-server/suites/did-spec/did-parameters.js
@@ -1,5 +1,10 @@
 const utils = require('./utils');
 
+// https://www.w3.org/TR/xmlschema11-2/#nt-dateTimeRep
+// Constrained to UTC and without sub-second decimal precision.
+// Note: day-of-month constraints not applied.
+const versionTimeRe = /^(-?(?:[1-9][0-9]{3,})|(?:0[0-9]{3}))-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T((?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]|24:00:00)(?:\.0+)?(?:Z|[+-]00:00)$/;
+
 const didParametersTests = (suiteConfig) => {
   if (suiteConfig.didParameters) {
     describe('did-parameters', () => {
@@ -27,6 +32,19 @@ const didParametersTests = (suiteConfig) => {
               }
             });
           }
+
+          if (didParameter === 'versionTime') {
+            it('MUST be [an ASCII string which is] a valid XML datetime value, as defined in section 3.3.7 of W3C XML Schema Definition Language (XSD) 1.1 Part 2: Datatypes [XMLSCHEMA11-2]. This datetime value MUST be normalized to UTC 00:00:00 and without sub-second decimal precision. For example: 2020-12-20T19:17:47Z.', async () => {
+              const didUrl = suiteConfig.didParameters[didParameter];
+              const param = utils.getQueryParamValueFromDidUri(
+                didUrl,
+                'versionTime'
+              );
+
+              expect(versionTimeRe.test(param)).toBe(true);
+            });
+          }
+
         });
       });
     });

--- a/packages/did-core-test-server/suites/did-spec/did-parameters.js
+++ b/packages/did-core-test-server/suites/did-spec/did-parameters.js
@@ -10,14 +10,21 @@ const didParametersTests = (suiteConfig) => {
     describe('did-parameters', () => {
       Object.keys(suiteConfig.didParameters).forEach((didParameter) => {
         describe(didParameter, () => {
-          it('The associated value MUST be an ASCII string.', async () => {
-            const didUrl = suiteConfig.didParameters[didParameter];
-            const param = utils.getQueryParamValueFromDidUri(
-              didUrl,
-              didParameter
-            );
-            expect(utils.isAsciiString(param)).toBe(true);
-          });
+          if (didParameter === 'service'
+           || didParameter === 'relativeRef'
+           || didParameter === 'versionId'
+           || didParameter === 'versionTime'
+           || didParameter === 'hl'
+          ) {
+            it('The associated value MUST be an ASCII string.', async () => {
+              const didUrl = suiteConfig.didParameters[didParameter];
+              const param = utils.getQueryParamValueFromDidUri(
+                didUrl,
+                didParameter
+              );
+              expect(utils.isAsciiString(param)).toBe(true);
+            });
+          }
 
           if (didParameter === 'relativeRef') {
             it('MUST use percent-encoding for certain characters as specified in RFC3986 Section 2.1.', async () => {

--- a/test-vectors/did-spec.latest.json
+++ b/test-vectors/did-spec.latest.json
@@ -67,7 +67,7 @@
           "did-spec",
           "did:example",
           "did-parameters",
-          "relative-ref"
+          "relativeRef"
         ],
         "title": "The associated value MUST be an ASCII string.",
         "status": "passed"
@@ -77,7 +77,7 @@
           "did-spec",
           "did:example",
           "did-parameters",
-          "relative-ref"
+          "relativeRef"
         ],
         "title": "MUST use percent-encoding for certain characters as specified in RFC3986 Section 2.1.",
         "status": "passed"
@@ -87,7 +87,7 @@
           "did-spec",
           "did:example",
           "did-parameters",
-          "version-id"
+          "versionId"
         ],
         "title": "The associated value MUST be an ASCII string.",
         "status": "passed"
@@ -97,7 +97,7 @@
           "did-spec",
           "did:example",
           "did-parameters",
-          "version-time"
+          "versionTime"
         ],
         "title": "The associated value MUST be an ASCII string.",
         "status": "passed"


### PR DESCRIPTION
This is aimed at fixing #22.
- Update DID parameters to use camelCase, following https://github.com/w3c/did-core/pull/553.
- Test `versionTime` DID parameter. Update test case to use [xsd:dateTime](https://www.w3.org/TR/xmlschema11-2/#dateTime) rather than UNIX timestamp, to match DID Core.
- Check that DID parameter values are ASCII only as specified in DID Core, rather than for all possible DID parameters.

Notes/questions:
- The `versionTime` test validates the parameter with a regex based on the [lexical representation of xsd:dateTime](https://www.w3.org/TR/xmlschema11-2/#nt-dateTimeRep) with the constraints for `versionTime` applied. But the [day-of-month constraints](https://www.w3.org/TR/xmlschema11-2/#con-dateTime-dayValue) are not checked (e.g. when is February 29th a valid date). Should we check these day-of-month constraints too?
- Should more exhaustive tests be done for percent-encoding in `relativeRef`?
- Should negative test cases be added? We could add an area in the input config [didParameters](https://github.com/spruceid/did-test-suite/blob/9025962c284115321afa5125612e474b815d4f18/packages/did-core-test-server/suites/did-spec/defaultSuiteConfig.json#L10) object for "bad" DID URLs, and check that they do not pass validation.
- Should all the DID parameter tests be applied to each tested DID URL? Currently the tests for `relativeRef` and `versionTime` are only applied to their respectively labeled test cases in the [config](https://github.com/spruceid/did-test-suite/blob/9025962c284115321afa5125612e474b815d4f18/packages/did-core-test-server/suites/did-spec/defaultSuiteConfig.json#L10-L16). This means there could be invalid uses of these parameters in the other DID URLs which would not be detected here. I wonder if this could be a source for confusion. We could instead apply all DID parameter tests to all DID URLs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 19, 2021, 5:27 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fspruceid%2Fdid-test-suite%2F7925112b59a2f92ee820d0afe03034e9f05af3c9%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: https://rawcdn.githack.com/spruceid/did-test-suite/7925112b59a2f92ee820d0afe03034e9f05af3c9/index.html?isPreview=true&publishDate=2021-03-19
ReSpec version: 26.3.0
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: TypeError: Cannot destructure property 'rsDocToDataURL' of '(intermediate value)' as it is undefined.
    at evaluateHTML (__puppeteer_evaluation_script__:23:13)
    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:218:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:107:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:207:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:86:18)
    at async Object.generate [as respec] (/u/spec-generator/generators/respec.js:13:40)
    at async /u/spec-generator/server.js:89:44

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/did-test-suite%2334.)._
</details>
