### PR TITLE
Feat/did document metadata

### DIFF
--- a/packages/did-core-test-server/suites/did-spec/defaultSuiteConfig.json
+++ b/packages/did-core-test-server/suites/did-spec/defaultSuiteConfig.json
@@ -12,7 +12,7 @@
         "service": "did:example:123?service=agent&relativeRef=%2Fpath%2Fto%2Fresource",
         "relative-ref": "did:example:123?service=agent&relativeRef=%2Fpath%2Fto%2Fresource",
         "version-id": "did:example:123?version-id=0.1.0",
-        "version-time": "did:example:123?version-time=1601151242"
+        "version-time": "did:example:123?version-time=2020-09-26T20:14:02.000Z"
       },
       "did:example:123": {
         "application/did+json": {
@@ -49,10 +49,10 @@
             "capabilityDelegation": ["#key-0"],
             "keyAgreement": ["#key-1"]
           },
-          "didDocumentMetaData": {
+          "didDocumentMetadata": {
             "content-type": "application/did+json"
           },
-          "didResolutionMetaData": {}
+          "didResolutionMetadata": {}
         },
         "application/did+ld+json": {
           "didDocument": {
@@ -78,10 +78,10 @@
             "capabilityDelegation": ["#key-0"],
             "keyAgreement": ["#key-1"]
           },
-          "didDocumentMetaData": {
+          "didDocumentMetadata": {
             "content-type": "application/did+ld+json"
           },
-          "didResolutionMetaData": {}
+          "didResolutionMetadata": {}
         }
       },
       "did:Cool": {
@@ -93,10 +93,10 @@
               "id": "did:Cool:123",
               "forbidden__proto__": { "vulnerable": "cool?" }
             },
-            "didDocumentMetaData": {
+            "didDocumentMetadata": {
               "content-type": "application/did+cool+json"
             },
-            "didResolutionMetaData": {}
+            "didResolutionMetadata": {}
           }
         }
       }

--- a/packages/did-core-test-server/suites/did-spec/defaultSuiteConfig.json
+++ b/packages/did-core-test-server/suites/did-spec/defaultSuiteConfig.json
@@ -19,8 +19,6 @@
           "didDocument": {
             "@context": ["https://www.w3.org/ns/did/v1"],
             "id": "did:example:123",
-            "canonicalId": "did:example:one-two-three",
-            "equivalentId": "did:example:one-two-three",
             "verificationMethod": [
               {
                 "id": "#key-0",
@@ -52,7 +50,10 @@
           "didDocumentMetadata": {
             "content-type": "application/did+json"
           },
-          "didResolutionMetadata": {}
+          "didResolutionMetadata": {
+            "canonicalId": "did:example:one-two-three",
+            "equivalentId": "did:example:one-two-three"
+          }
         },
         "application/did+ld+json": {
           "didDocument": {

--- a/packages/did-core-test-server/suites/did-spec/defaultSuiteConfig.json
+++ b/packages/did-core-test-server/suites/did-spec/defaultSuiteConfig.json
@@ -57,7 +57,7 @@
             "nextVersionId": "0.2.0"
           },
           "didResolutionMetadata": {
-            "content-type": "application/did+json"
+            "contentType": "application/did+json"
           }
         },
         "application/did+ld+json": {
@@ -86,7 +86,7 @@
           },
           "didDocumentMetadata": {},
           "didResolutionMetadata": {
-            "content-type": "application/did+ld+json"
+            "contentType": "application/did+ld+json"
           }
         }
       },
@@ -101,7 +101,7 @@
             },
             "didDocumentMetadata": {},
             "didResolutionMetadata": {
-              "content-type": "application/did+cool+json"
+              "contentType": "application/did+cool+json"
             }
           }
         }

--- a/packages/did-core-test-server/suites/did-spec/defaultSuiteConfig.json
+++ b/packages/did-core-test-server/suites/did-spec/defaultSuiteConfig.json
@@ -48,11 +48,16 @@
             "keyAgreement": ["#key-1"]
           },
           "didDocumentMetadata": {
-            "content-type": "application/did+json"
+            "canonicalId": "did:example:one-two-three",
+            "equivalentId": "did:example:one-two-three",
+            "created": "2020-09-26T20:14:02.000Z",
+            "updated": "2020-09-27T20:14:02.000Z",
+            "nextUpdate": "2020-09-28T20:14:02.000Z",
+            "versionId": "0.1.0",
+            "nextVersionId": "0.2.0"
           },
           "didResolutionMetadata": {
-            "canonicalId": "did:example:one-two-three",
-            "equivalentId": "did:example:one-two-three"
+            "content-type": "application/did+json"
           }
         },
         "application/did+ld+json": {
@@ -79,10 +84,10 @@
             "capabilityDelegation": ["#key-0"],
             "keyAgreement": ["#key-1"]
           },
-          "didDocumentMetadata": {
+          "didDocumentMetadata": {},
+          "didResolutionMetadata": {
             "content-type": "application/did+ld+json"
-          },
-          "didResolutionMetadata": {}
+          }
         }
       },
       "did:Cool": {
@@ -94,10 +99,10 @@
               "id": "did:Cool:123",
               "forbidden__proto__": { "vulnerable": "cool?" }
             },
-            "didDocumentMetadata": {
+            "didDocumentMetadata": {},
+            "didResolutionMetadata": {
               "content-type": "application/did+cool+json"
-            },
-            "didResolutionMetadata": {}
+            }
           }
         }
       }

--- a/packages/did-core-test-server/suites/did-spec/did-resolution.js
+++ b/packages/did-core-test-server/suites/did-spec/did-resolution.js
@@ -1,3 +1,5 @@
+const utils = require('./utils');
+
 const didResolutionTests = (suiteConfig) => {
   describe('resolution', () => {
     suiteConfig.dids.forEach((didExample) => {
@@ -13,7 +15,7 @@ const didResolutionTests = (suiteConfig) => {
             });
 
             if (
-              suiteConfig[didExample][contentType].didDocument['canonicalId']
+              suiteConfig[didExample][contentType].didDocumentMetadata['canonicalId']
             ) {
               describe('canonicalId', () => {
                 it('MUST be of the same DID Method as the resolved ID', async () => {
@@ -73,6 +75,82 @@ const didResolutionTests = (suiteConfig) => {
                   expect(primaryId).toBeDefined();
                 });
               });
+            }
+
+            if (suiteConfig[didExample][contentType].didDocumentMetadata['created']) {
+              describe('created', () => {
+                it('Must be an XML Datetime', async () => {
+                  const {
+                    didDocumentMetadata: { created }
+                  } = suiteConfig[didExample][contentType];
+                  expect(utils.isXmlDatetime(created)).toBe(true)
+                })
+              })
+            }
+
+            if (suiteConfig[didExample][contentType].didDocumentMetadata['updated']) {
+              describe('updated', () => {
+                it('Must be an XML Datetime', async () => {
+                  const {
+                    didDocumentMetadata: { updated }
+                  } = suiteConfig[didExample][contentType];
+                  expect(utils.isXmlDatetime(updated)).toBe(true)
+                })
+
+                it('Must be larger than or equal to "created"', async () => {
+                  const {
+                    didDocumentMetadata: { created, updated }
+                  } = suiteConfig[didExample][contentType];
+                  expect((new Date(updated)).getTime()).toBeGreaterThanOrEqual((new Date(created)).getTime())
+                })
+              })
+            }
+
+            if (suiteConfig[didExample][contentType].didDocumentMetadata['nextUpdate']) {
+              describe('nextUpdate', () => {
+                it('Must be an XML Datetime', async () => {
+                  const {
+                    didDocumentMetadata: { nextUpdate }
+                  } = suiteConfig[didExample][contentType];
+                  expect(utils.isXmlDatetime(nextUpdate)).toBe(true)
+                })
+
+                it('Must be larger than to "updated"', async () => {
+                  const {
+                    didDocumentMetadata: { updated, nextUpdate }
+                  } = suiteConfig[didExample][contentType];
+                  expect((new Date(nextUpdate)).getTime()).toBeGreaterThan((new Date(updated)).getTime())
+                })
+              })
+            }
+
+            if (suiteConfig[didExample][contentType].didDocumentMetadata['versionId']) {
+              describe('versionId', () => {
+                it('Must be an ASCII string', async () => {
+                  const {
+                    didDocumentMetadata: { versionId }
+                  } = suiteConfig[didExample][contentType];
+                  expect(utils.isAsciiString(versionId)).toBe(true);
+                })
+              })
+            }
+
+            if (suiteConfig[didExample][contentType].didDocumentMetadata['nextVersionId']) {
+              describe('nextVersionId', () => {
+                it('Must be an ASCII string', async () => {
+                  const {
+                    didDocumentMetadata: { nextVersionId }
+                  } = suiteConfig[didExample][contentType];
+                  expect(utils.isAsciiString(nextVersionId)).toBe(true);
+                })
+
+                it('Must not be equal to versionId', async () => {
+                  const {
+                    didDocumentMetadata: { versionId, nextVersionId }
+                  } = suiteConfig[didExample][contentType];
+                  expect(nextVersionId).not.toEqual(versionId)
+                })
+              })
             }
           });
         });

--- a/packages/did-core-test-server/suites/did-spec/did-resolution.js
+++ b/packages/did-core-test-server/suites/did-spec/did-resolution.js
@@ -19,7 +19,7 @@ const didResolutionTests = (suiteConfig) => {
                 it('MUST be of the same DID Method as the resolved ID', async () => {
                   const canonicalIdMethod = suiteConfig[didExample][
                     contentType
-                  ].didDocument['canonicalId'].split(':')[1];
+                  ].didDocumentMetadata['canonicalId'].split(':')[1];
                   const resolvedIdMethod = didExample.split(':')[1];
                   expect(canonicalIdMethod).toBe(resolvedIdMethod);
                 });
@@ -29,16 +29,16 @@ const didResolutionTests = (suiteConfig) => {
                 });
 
                 if (
-                  suiteConfig[didExample][contentType].didDocument
+                  suiteConfig[didExample][contentType].didDocumentMetadata
                     .canonicalId !==
-                  suiteConfig[didExample][contentType].didDocument.id
+                  suiteConfig[didExample][contentType].didDocumentMetadata.id
                 ) {
                   it('If the resolved ID differs from canonicalId, it must be recognized as an equivalent reference', async () => {
                     expect(
-                      suiteConfig[didExample][contentType].didDocument
+                      suiteConfig[didExample][contentType].didDocumentMetadata
                         .equivalentId
                     ).toBe(
-                      suiteConfig[didExample][contentType].didDocument
+                      suiteConfig[didExample][contentType].didDocumentMetadata
                         .canonicalId
                     );
                   });
@@ -47,12 +47,12 @@ const didResolutionTests = (suiteConfig) => {
             }
 
             if (
-              suiteConfig[didExample][contentType].didDocument['equivalentId']
+              suiteConfig[didExample][contentType].didDocumentMetadata['equivalentId']
             ) {
               describe('equivalentId', () => {
                 it('MUST be of the same DID Method as the resolved ID', async () => {
-                  const { didDocument } = suiteConfig[didExample][contentType];
-                  const equivalentIdMethod = didDocument.equivalentId.split(
+                  const { didDocumentMetadata } = suiteConfig[didExample][contentType];
+                  const equivalentIdMethod = didDocumentMetadata.equivalentId.split(
                     ':'
                   )[1];
                   const resolvedIdMethod = didExample.split(':')[1];
@@ -60,16 +60,16 @@ const didResolutionTests = (suiteConfig) => {
                 });
 
                 it('Its values must be recognized as equivalent ID references.', async () => {
-                  const { didDocument } = suiteConfig[didExample][contentType];
-                  const equivalentId = didDocument.equivalentId;
+                  const { didDocumentMetadata } = suiteConfig[didExample][contentType];
+                  const equivalentId = didDocumentMetadata.equivalentId;
                   expect(equivalentId).toBeDefined();
                 });
 
                 it('Resolved ID must be recognized as the primary reference, absent a specified canonicalId', async () => {
-                  const { didDocument } = suiteConfig[didExample][contentType];
-                  const primaryId = !didDocument.canonicalId
-                    ? didDocument.id
-                    : didDocument.equivalentId;
+                  const { didDocumentMetadata } = suiteConfig[didExample][contentType];
+                  const primaryId = !didDocumentMetadata.canonicalId
+                    ? didDocumentMetadata.id
+                    : didDocumentMetadata.equivalentId;
                   expect(primaryId).toBeDefined();
                 });
               });

--- a/packages/did-core-test-server/suites/did-spec/utils.js
+++ b/packages/did-core-test-server/suites/did-spec/utils.js
@@ -18,7 +18,14 @@ const isValidURL = (data) => {
   return valid;
 };
 
+
+const isXmlDatetime = (data) => {
+  const regex = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/
+  return regex.test(data)
+};
+
 module.exports = {
+  isXmlDatetime,
   isValidURL,
   isAsciiString,
   getQueryParamValueFromDidUri,


### PR DESCRIPTION
This PR mainly adds tests for the following **DID Document Metadata** properties:
* created
* updated
* nextUpdate
* versionId
* nextVersionId

In addition it fixed a few problems with the testsuite:
* `content-type` -> `contentType`
* `contentType` should be on `didResolutionMetadata`
* `canonicalId` and `equivalentId` should be in `didDocumentMetadata`
* `versionTime` param should be XML Datetime