### PR TITLE
Add Producer tests for Section 1.4 and Section 6.1.

### DIFF
--- a/packages/did-core-test-server/suites/did-spec/did-producer.js
+++ b/packages/did-core-test-server/suites/did-spec/did-producer.js
@@ -6,8 +6,30 @@ const generateDidProducerTests = ({did, resolutionResult}) => {
   const {didDocument} = resolutionResult;
   const contentType = resolutionResult.didDocumentMetaData['content-type'];
 
-  it('1.4 Conformance - A conforming producer MUST NOT produce ' +
-    'non-conforming DIDs or DID documents.', async () => {
+  it('6.1 Production and Consumption - A conforming producer MUST take a ' +
+    'DID document data model and a representation-specific entries map as ' +
+    'input into the production process. The conforming producer MAY accept ' +
+    'additional options as input into the production process.', async () => {
+      if(jsonMediaTypes.includes('application/did+ld+json')) {
+        const context = didDocument['@context'];
+        if(typeof context === 'string') {
+          expect(context).toBe('https://www.w3.org/ns/did/v1');
+        } else if(Array.isArray(context)) {
+          expect(context[0]).toBe('https://www.w3.org/ns/did/v1');
+          reserializedContext = JSON.parse(JSON.stringify(context));
+          expect(deepEqual(context, reserializedContext)).toBe(true);
+        } else {
+          throw new Error('Invalid @context value '+ context);
+        }
+      }
+  });
+
+  it('6.1 Production and Consumption - A conforming producer MUST ' +
+    'serialize all entries in the DID document data model, and the ' +
+    'representation-specific entries map, that do not have explicit ' +
+    'processing rules for the representation being produced using only the ' +
+    'representation\'s data type processing rules and return the ' +
+    'serialization after the production process completes.', async () => {
       if(jsonMediaTypes.includes(contentType)) {
         reserializedDidDocument = JSON.parse(JSON.stringify(didDocument));
         expect(deepEqual(didDocument, reserializedDidDocument)).toBe(true);
@@ -16,22 +38,20 @@ const generateDidProducerTests = ({did, resolutionResult}) => {
       }
   });
 
-  it('6.1 Production and Consumption - A conforming producer MUST serialize ' +
-    'all entries in the data model that do not have explicit processing ' +
-    'rules for the representation being produced using only the ' +
-    'representation\'s data type processing rules.', async () => {
-      if(jsonMediaTypes.includes(contentType)) {
-        reserializedDidDocument = JSON.parse(JSON.stringify(didDocument));
-        expect(deepEqual(didDocument, reserializedDidDocument)).toBe(true);
-      } else {
-        throw new Error('Unknown producer for content-type: '+ contentType);
-      }
-  });
-
-  it('6.1 Production and Consumption - A conforming producer MUST indicate ' +
-    'which representation has been used for a DID document via a Media Type ' +
-    'as described in § 7.1.2 DID Resolution Metadata.', async () => {
+  it('6.1 Production and Consumption - A conforming producer MUST return ' +
+    'the Media Type string associated with the representation after the ' +
+    'production process completes.', async () => {
       expect(typeof contentType === 'string').toBe(true);
+  });
+
+  it('6.1 Production and Consumption - A conforming producer MUST NOT ' +
+    'produce non-conforming DIDs or DID documents.', async () => {
+      if(jsonMediaTypes.includes(contentType)) {
+        reserializedDidDocument = JSON.parse(JSON.stringify(didDocument));
+        expect(deepEqual(didDocument, reserializedDidDocument)).toBe(true);
+      } else {
+        throw new Error('Unknown producer for content-type: '+ contentType);
+      }
   });
 }
 

--- a/packages/did-core-test-server/suites/did-spec/did-producer.js
+++ b/packages/did-core-test-server/suites/did-spec/did-producer.js
@@ -4,13 +4,13 @@ const deepEqual = require('deep-equal')
 
 const generateDidProducerTests = ({did, resolutionResult}) => {
   const {didDocument} = resolutionResult;
-  const contentType = resolutionResult.didDocumentMetaData['content-type'];
+  const contentType = resolutionResult.didResolutionMetadata['contentType'];
 
   it('6.1 Production and Consumption - A conforming producer MUST take a ' +
     'DID document data model and a representation-specific entries map as ' +
     'input into the production process. The conforming producer MAY accept ' +
     'additional options as input into the production process.', async () => {
-      if(jsonMediaTypes.includes('application/did+ld+json')) {
+      if(contentType === 'application/did+ld+json') {
         const context = didDocument['@context'];
         if(typeof context === 'string') {
           expect(context).toBe('https://www.w3.org/ns/did/v1');

--- a/packages/did-core-test-server/suites/did-spec/did-producer.js
+++ b/packages/did-core-test-server/suites/did-spec/did-producer.js
@@ -1,0 +1,50 @@
+const utils = require('./utils');
+const jsonMediaTypes = ['application/did+ld+json', 'application/did+json'];
+const deepEqual = require('deep-equal')
+
+const generateDidProducerTests = ({did, resolutionResult}) => {
+  const {didDocument} = resolutionResult;
+  const contentType = resolutionResult.didDocumentMetaData['content-type'];
+
+  it('1.4 Conformance - A conforming producer MUST NOT produce ' +
+    'non-conforming DIDs or DID documents.', async () => {
+      if(jsonMediaTypes.includes(contentType)) {
+        reserializedDidDocument = JSON.parse(JSON.stringify(didDocument));
+        expect(deepEqual(didDocument, reserializedDidDocument)).toBe(true);
+      } else {
+        throw new Error('Unknown producer for content-type: '+ contentType);
+      }
+  });
+
+  it('6.1 Production and Consumption - A conforming producer MUST serialize ' +
+    'all entries in the data model that do not have explicit processing ' +
+    'rules for the representation being produced using only the ' +
+    'representation\'s data type processing rules.', async () => {
+      if(jsonMediaTypes.includes(contentType)) {
+        reserializedDidDocument = JSON.parse(JSON.stringify(didDocument));
+        expect(deepEqual(didDocument, reserializedDidDocument)).toBe(true);
+      } else {
+        throw new Error('Unknown producer for content-type: '+ contentType);
+      }
+  });
+
+  it('6.1 Production and Consumption - A conforming producer MUST indicate ' +
+    'which representation has been used for a DID document via a Media Type ' +
+    'as described in § 7.1.2 DID Resolution Metadata.', async () => {
+      expect(typeof contentType === 'string').toBe(true);
+  });
+}
+
+const didProducerTests = (suiteConfig) => {
+  describe('did-producer', () => {
+    suiteConfig.dids.forEach((did) => {
+      describe(did, () => {
+        for(const [mediaType, resolutionResult] of Object.entries(suiteConfig[did])) {
+          generateDidProducerTests({did, resolutionResult});
+        }
+      });
+    });
+  });
+};
+
+module.exports = { didProducerTests };

--- a/packages/did-core-test-server/suites/did-spec/did.spec.js
+++ b/packages/did-core-test-server/suites/did-spec/did.spec.js
@@ -18,6 +18,12 @@ describe('did-spec', () => {
       require('./did-jsonld-production').didJsonldProductionTests(
         didMethodSuiteConfig
       );
+      require('./did-producer').didProducerTests(
+        didMethodSuiteConfig
+      );
+      require('./did-jsonld-consumption').didJsonldConsumptionTests(
+        didMethodSuiteConfig
+      );
       require('./did-resolution').didResolutionTests(didMethodSuiteConfig);
     });
   });

--- a/packages/did-core-test-server/suites/did-spec/did.spec.js
+++ b/packages/did-core-test-server/suites/did-spec/did.spec.js
@@ -21,9 +21,6 @@ describe('did-spec', () => {
       require('./did-producer').didProducerTests(
         didMethodSuiteConfig
       );
-      require('./did-jsonld-consumption').didJsonldConsumptionTests(
-        didMethodSuiteConfig
-      );
       require('./did-resolution').didResolutionTests(didMethodSuiteConfig);
     });
   });


### PR DESCRIPTION
Implement the tests needed by issue #24.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 24, 2021, 2:01 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fdid-test-suite%2F37057d1553566e0b38f2bf21e49bb3b8c0ce8373%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: https://rawcdn.githack.com/w3c/did-test-suite/37057d1553566e0b38f2bf21e49bb3b8c0ce8373/index.html?isPreview=true&publishDate=2021-03-24
ReSpec version: 26.4.0
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: TypeError: Cannot destructure property 'rsDocToDataURL' of '(intermediate value)' as it is undefined.
    at evaluateHTML (__puppeteer_evaluation_script__:23:13)
    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:218:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:107:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:207:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:86:18)
    at async Object.generate [as respec] (/u/spec-generator/generators/respec.js:13:40)
    at async /u/spec-generator/server.js:89:44

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/did-test-suite%2341.)._
</details>
