### PR TITLE
Organize DID Parameter tests by section

### DIFF
--- a/packages/did-core-test-server/suites/did-spec/did-parameters.js
+++ b/packages/did-core-test-server/suites/did-spec/did-parameters.js
@@ -10,45 +10,43 @@ const didParametersTests = (suiteConfig) => {
     describe('did-parameters', () => {
       Object.keys(suiteConfig.didParameters).forEach((didParameter) => {
         describe(didParameter, () => {
-          if (didParameter === 'service'
-           || didParameter === 'relativeRef'
-           || didParameter === 'versionId'
-           || didParameter === 'versionTime'
-           || didParameter === 'hl'
-          ) {
-            it('The associated value MUST be an ASCII string.', async () => {
-              const didUrl = suiteConfig.didParameters[didParameter];
-              const param = utils.getQueryParamValueFromDidUri(
-                didUrl,
-                didParameter
-              );
+          const didUrl = suiteConfig.didParameters[didParameter];
+          const param = utils.getQueryParamValueFromDidUri(
+            didUrl,
+            didParameter
+          );
+
+          if (didParameter === 'service') {
+            it('3.2.1 DID Parameters - service - If present, the associated value MUST be an ASCII string.', async () => {
               expect(utils.isAsciiString(param)).toBe(true);
             });
           }
 
           if (didParameter === 'relativeRef') {
-            it('MUST use percent-encoding for certain characters as specified in RFC3986 Section 2.1.', async () => {
-              const didUrl = suiteConfig.didParameters[didParameter];
-              const param = utils.getQueryParamValueFromDidUri(
-                didUrl,
-                'relativeRef'
-              );
-
+            it('3.2.1 DID Parameters - relativeRef - If present, the associated value MUST be an ASCII string and MUST use percent-encoding for certain characters as specified in RFC3986 Section 2.1.', async () => {
+              expect(utils.isAsciiString(param)).toBe(true);
               if (param.includes('/')) {
                 expect(didUrl.includes('%2F')).toBe(true);
               }
             });
           }
 
-          if (didParameter === 'versionTime') {
-            it('MUST be [an ASCII string which is] a valid XML datetime value, as defined in section 3.3.7 of W3C XML Schema Definition Language (XSD) 1.1 Part 2: Datatypes [XMLSCHEMA11-2]. This datetime value MUST be normalized to UTC 00:00:00 and without sub-second decimal precision. For example: 2020-12-20T19:17:47Z.', async () => {
-              const didUrl = suiteConfig.didParameters[didParameter];
-              const param = utils.getQueryParamValueFromDidUri(
-                didUrl,
-                'versionTime'
-              );
+          if (didParameter === 'versionId') {
+            it('3.2.1 DID Parameters - versionId - If present, the associated value MUST be an ASCII string.', async () => {
+              expect(utils.isAsciiString(param)).toBe(true);
+            });
+          }
 
+          if (didParameter === 'versionTime') {
+            it('3.2.1 DID Parameters - versionTime - If present, the associated value MUST be an ASCII string which is a valid XML datetime value, as defined in section 3.3.7 of W3C XML Schema Definition Language (XSD) 1.1 Part 2: Datatypes [XMLSCHEMA11-2]. This datetime value MUST be normalized to UTC 00:00:00 and without sub-second decimal precision. For example: 2020-12-20T19:17:47Z.', async () => {
+              expect(utils.isAsciiString(param)).toBe(true);
               expect(versionTimeRe.test(param)).toBe(true);
+            });
+          }
+
+          if (didParameter === 'hl') {
+            it('3.2.1 DID Parameters - hl - If present, the associated value MUST be an ASCII string.', async () => {
+              expect(utils.isAsciiString(param)).toBe(true);
             });
           }
 


### PR DESCRIPTION
Add Section numbers to tests for DID parameters, as requested in https://github.com/w3c/did-test-suite/issues/22#issuecomment-807298139.