### PR TITLE
Fix to isXmlDatetime utility function to not allowing sub-seconds

### DIFF
--- a/packages/did-core-test-server/suites/utils.js
+++ b/packages/did-core-test-server/suites/utils.js
@@ -50,7 +50,7 @@ const isValidURL = (data) => {
 };
 
 const isXmlDatetime = (data) => {
-  const regex = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/
+  const regex = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/
   return regex.test(data)
 };
 


### PR DESCRIPTION
The function definition includes sub-seconds but the spec doesn't allow sub-seconds.

Luckily, no tests using this predicate up to now.
