### PR TITLE
Fixing regexp for util.js:isValidDid to add pct-encoded character support

### DIFF
--- a/packages/did-core-test-server/suites/utils.js
+++ b/packages/did-core-test-server/suites/utils.js
@@ -18,7 +18,7 @@ const isValidBase58 = (value) => {
 };
 
 const isValidDID = (did) => {
-  const didRegex = /did:(?<method>[a-z0-9]+):(?<idchar>[a-zA-Z0-9:\\-_]+)/;
+  const didRegex = /did:(?<method>[a-z0-9]+):(?<idchar>([a-zA-Z0-9.\-_]|%[0-9a-fA-F]{2})+)/;
 
   return didRegex.test(did);
 };


### PR DESCRIPTION
Allowing pct-encoded characters.

I also think `isValidDid` require anchoring at the begning and the end of string. current regexp matcher matches not only DID but also DID URL. This predicate also matches DID string in the middile of strings.

Maybe better to use isValidDid predicate and toBeValidDid matcher in `jest-did-matcher` packages.

Actually I added `^` and `$` and experimented -- raised lot of errors.
We need to adjust the tests for the purpose of the match.
