### PR TITLE
Update identifier, core properties, and production suites to use new jest extensions

### DIFF
--- a/packages/did-core-test-server/suites/did-core-properties/did-core-properties.js
+++ b/packages/did-core-test-server/suites/did-core-properties/did-core-properties.js
@@ -15,7 +15,7 @@ const generateDidCorePropertiesTests = (
     'conforms to the rules in § 3.1 DID Syntax and MUST exist in the root ' +
     'map of the data model for the DID document.', async () => {
       expect(didDocument).toHaveProperty('id');
-      expect(isValidDID(didDocument.id)).toBe(true);
+      expect(didDocument.id).toBeValidDid();
   });
 
   it('5.1.2 DID Controller - The controller property is OPTIONAL. If ' +
@@ -26,7 +26,7 @@ const generateDidCorePropertiesTests = (
         const controllers =
           (Array.isArray(controller)) ? controller : [controller];
         controllers.forEach(didController => {
-          expect(isValidDID(didController)).toBe(true);
+          expect(didController).toBeValidDid();
         });
       }
   });
@@ -38,7 +38,7 @@ const generateDidCorePropertiesTests = (
       if(alsoKnownAs) {
         expect(Array.isArray(alsoKnownAs)).toBe(true);
         alsoKnownAs.forEach(alsoKnownAsValue => {
-          expect(isValidURI(alsoKnownAsValue)).toBe(true);
+          expect(alsoKnownAsValue).toBeValidUri();
         });
       }
   });
@@ -51,7 +51,7 @@ const generateDidCorePropertiesTests = (
       if(verificationMethod) {
         expect(Array.isArray(verificationMethod)).toBe(true);
         verificationMethod.forEach(verificationMethodValue => {
-          expect(isValidURI(verificationMethodValue)).toBe(true);
+          expect(verificationMethodValue).toBeInfraMap();
         });
       }
   });
@@ -73,7 +73,7 @@ const generateDidCorePropertiesTests = (
     'Section § 3.2 DID URL Syntax.', async () => {
       const verificationMethods = getAllVerificationMethods(didDocument);
       verificationMethods.forEach(vm => {
-        expect(isValidDID(vm.id)).toBe(true);
+        expect(vm.id).toBeValidDidUrl();
       });
   });
 
@@ -82,7 +82,7 @@ const generateDidCorePropertiesTests = (
     async () => {
       const verificationMethods = getAllVerificationMethods(didDocument);
       verificationMethods.forEach(vm => {
-        expect(typeof vm.type === 'string').toBe(true);
+        expect(vm.type).toBeInfraString();
       });
   });
 
@@ -91,7 +91,7 @@ const generateDidCorePropertiesTests = (
     async () => {
       const verificationMethods = getAllVerificationMethods(didDocument);
       verificationMethods.forEach(vm => {
-        expect(isValidDID(vm.controller)).toBe(true);
+        expect(vm.controller).toBeValidDid();
       });
   });
 
@@ -102,7 +102,7 @@ const generateDidCorePropertiesTests = (
       verificationMethods.forEach(vm => {
         const {publicKeyBase58} = vm;
         if(publicKeyBase58) {
-          expect(isValidBase58(publicKeyBase58)).toBe(true);
+          expect(publicKeyBase58).toBeBase58String();
         }
       });
   });
@@ -162,7 +162,7 @@ const generateDidCorePropertiesTests = (
       authentication?.forEach(vm => {
         if(typeof vm === 'string') {
           let absoluteURL = getAbsoluteDIDURL(didDocument.id, vm);
-          expect(isValidDID(absoluteURL)).toBe(true);
+          expect(absoluteURL).toBeValidDidUrl();
         } else {
           expect(isValidVerificationMethod(vm)).toBe(true);
         }
@@ -176,7 +176,7 @@ const generateDidCorePropertiesTests = (
       assertionMethod?.forEach(vm => {
         if(typeof vm === 'string') {
           let absoluteURL = getAbsoluteDIDURL(didDocument.id, vm);
-          expect(isValidDID(absoluteURL)).toBe(true);
+          expect(absoluteURL).toBeValidDidUrl();
         } else {
           expect(isValidVerificationMethod(vm)).toBe(true);
         }
@@ -190,7 +190,7 @@ const generateDidCorePropertiesTests = (
       keyAgreement?.forEach(vm => {
         if(typeof vm === 'string') {
           let absoluteURL = getAbsoluteDIDURL(didDocument.id, vm);
-          expect(isValidDID(absoluteURL)).toBe(true);
+          expect(absoluteURL).toBeValidDidUrl();
         } else {
           expect(isValidVerificationMethod(vm)).toBe(true);
         }
@@ -204,7 +204,7 @@ const generateDidCorePropertiesTests = (
       capabilityInvocation?.forEach(vm => {
         if(typeof vm === 'string') {
           let absoluteURL = getAbsoluteDIDURL(didDocument.id, vm);
-          expect(isValidDID(absoluteURL)).toBe(true);
+          expect(absoluteURL).toBeValidDidUrl();
         } else {
           expect(isValidVerificationMethod(vm)).toBe(true);
         }
@@ -218,7 +218,7 @@ const generateDidCorePropertiesTests = (
       capabilityDelegation?.forEach(vm => {
         if(typeof vm === 'string') {
           let absoluteURL = getAbsoluteDIDURL(didDocument.id, vm);
-          expect(isValidDID(absoluteURL)).toBe(true);
+          expect(absoluteURL).toBeValidDidUrl();
         } else {
           expect(isValidVerificationMethod(vm)).toBe(true);
         }
@@ -232,7 +232,7 @@ const generateDidCorePropertiesTests = (
       if(service) {
         expect(Array.isArray(service)).toBe(true);
         service.forEach(serviceValue => {
-          expect(typeof serviceValue === 'object').toBe(true);
+          expect(serviceValue).toBeInfraMap();
         });
       }
   });
@@ -254,7 +254,7 @@ const generateDidCorePropertiesTests = (
       const {service} = didDocument;
       if(service) {
         service.forEach(serviceValue => {
-          expect(isValidURI(serviceValue.id)).toBe(true);
+          expect(serviceValue.id).toBeValidUri();
         });
       }
   });
@@ -298,7 +298,7 @@ const generateDidCorePropertiesTests = (
           } else if(Array.isArray(serviceValue.type)) {
             const types = serviceValue.type;
             types.forEach(type => {
-              expect(typeof type === 'string').toBe(true);
+              expect(type).toBeInfraString();
             });
           } else {
             throw new Error('Invalid value for `type` property.');
@@ -343,7 +343,7 @@ const generateDidCorePropertiesTests = (
         service.forEach(serviceValue => {
           const {serviceEndpoint} = serviceValue;
           if(typeof serviceEndpoint === 'string') {
-            expect(isValidURI(serviceEndpoint)).toBe(true);
+            expect(serviceEndpoint).toBeValidUri();
           }
         });
       }

--- a/packages/did-core-test-server/suites/did-core-properties/did-core-properties.js
+++ b/packages/did-core-test-server/suites/did-core-properties/did-core-properties.js
@@ -36,7 +36,7 @@ const generateDidCorePropertiesTests = (
     'is a URI conforming to [RFC3986].', async () => {
       const {alsoKnownAs} = didDocument;
       if(alsoKnownAs) {
-        expect(Array.isArray(alsoKnownAs)).toBe(true);
+        expect(alsoKnownAs).toBeArray();
         alsoKnownAs.forEach(alsoKnownAsValue => {
           expect(alsoKnownAsValue).toBeValidUri();
         });
@@ -49,7 +49,7 @@ const generateDidCorePropertiesTests = (
     async () => {
       const {verificationMethod} = didDocument;
       if(verificationMethod) {
-        expect(Array.isArray(verificationMethod)).toBe(true);
+        expect(verificationMethod).toArray();
         verificationMethod.forEach(verificationMethodValue => {
           expect(verificationMethodValue).toBeInfraMap();
         });

--- a/packages/did-core-test-server/suites/did-identifier/did-parameters.js
+++ b/packages/did-core-test-server/suites/did-identifier/did-parameters.js
@@ -18,13 +18,13 @@ const didParametersTests = (suiteConfig) => {
 
           if (didParameter === 'service') {
             it('3.2.1 DID Parameters - service - If present, the associated value MUST be an ASCII string.', async () => {
-              expect(utils.isAsciiString(param)).toBe(true);
+              expect(param).toBeAsciiString();
             });
           }
 
           if (didParameter === 'relativeRef') {
             it('3.2.1 DID Parameters - relativeRef - If present, the associated value MUST be an ASCII string and MUST use percent-encoding for certain characters as specified in RFC3986 Section 2.1.', async () => {
-              expect(utils.isAsciiString(param)).toBe(true);
+              expect(param).toBeAsciiString();
               if (param.includes('/')) {
                 expect(didUrl.includes('%2F')).toBe(true);
               }
@@ -33,20 +33,20 @@ const didParametersTests = (suiteConfig) => {
 
           if (didParameter === 'versionId') {
             it('3.2.1 DID Parameters - versionId - If present, the associated value MUST be an ASCII string.', async () => {
-              expect(utils.isAsciiString(param)).toBe(true);
+              expect(param).toBeAsciiString();
             });
           }
 
           if (didParameter === 'versionTime') {
             it('3.2.1 DID Parameters - versionTime - If present, the associated value MUST be an ASCII string which is a valid XML datetime value, as defined in section 3.3.7 of W3C XML Schema Definition Language (XSD) 1.1 Part 2: Datatypes [XMLSCHEMA11-2]. This datetime value MUST be normalized to UTC 00:00:00 and without sub-second decimal precision. For example: 2020-12-20T19:17:47Z.', async () => {
-              expect(utils.isAsciiString(param)).toBe(true);
-              expect(versionTimeRe.test(param)).toBe(true);
+              expect(param).toBeAsciiString();
+              expect(param).toBeDidCoreDatetime();
             });
           }
 
           if (didParameter === 'hl') {
             it('3.2.1 DID Parameters - hl - If present, the associated value MUST be an ASCII string.', async () => {
-              expect(utils.isAsciiString(param)).toBe(true);
+              expect(param).toBeAsciiString();
             });
           }
 

--- a/packages/did-core-test-server/suites/did-identifier/did-syntax.js
+++ b/packages/did-core-test-server/suites/did-identifier/did-syntax.js
@@ -5,7 +5,7 @@ const didSyntaxTests = (suiteConfig) => {
     suiteConfig.dids.forEach((didExample) => {
       describe(didExample, () => {
         it('MUST be a valid URL.', async () => {
-          expect(utils.isValidURL(didExample)).toBe(true);
+          expect(didExample).toBeValidUrl();
         });
         it('The URI scheme MUST be "did:"', () => {
           const url = new URL(didExample);
@@ -13,7 +13,7 @@ const didSyntaxTests = (suiteConfig) => {
         });
         it('The DID method name MUST be an ASCII lowercase string.', () => {
           const method = didExample.split(':')[1];
-          expect(utils.isAsciiString(method)).toBe(true);
+          expect(method).toBeAsciiString();
           expect(method.toLowerCase()).toBe(method);
         });
         it('The DID method name MUST NOT be empty.', () => {


### PR DESCRIPTION
I updated the identifier, core properties, and production suites to use @shigeya (AWESOME!!!) new jest extensions. I also tested to make sure they fail when given invalid input as I went along (and they did). I haven't removed the util.js files just yet... we need to move everything over to the new jest matchers before removing the old `util.js` test functions.