### PR TITLE
Add JSON Production and Consumption tests.

### DIFF
--- a/packages/did-core-test-server/suites/did-consumption/did-consumption.spec.js
+++ b/packages/did-core-test-server/suites/did-consumption/did-consumption.spec.js
@@ -13,6 +13,9 @@ suiteConfig.didMethods.forEach((didMethodSuiteConfig) => {
     require('./did-consumer').didConsumerTests(
       didMethodSuiteConfig
     );
+    require('./did-json-consumption').didJsonConsumptionTests(
+      didMethodSuiteConfig
+    );
     require('./did-jsonld-consumption').didJsonldConsumptionTests(
       didMethodSuiteConfig
     );

--- a/packages/did-core-test-server/suites/did-consumption/did-json-consumption.js
+++ b/packages/did-core-test-server/suites/did-consumption/did-json-consumption.js
@@ -79,7 +79,7 @@ const generateJsonConsumptionTests = (
   it('6.2.2 JSON Consumption - A conforming consumer for a JSON ' +
     'representation that is consuming a DID document with a root ' +
     'element that is not a JSON Object MUST report an error.', () => {
-    expect(typeof didDocument === 'object');
+    expect(typeof didDocument === 'object').toBeTruthy();
   });
 
   it('6.2.2 JSON Production - If media type information is available to ' +

--- a/packages/did-core-test-server/suites/did-consumption/did-json-consumption.js
+++ b/packages/did-core-test-server/suites/did-consumption/did-json-consumption.js
@@ -18,14 +18,14 @@ const generateJsonConsumptionTests = (
           'Array is added to the list in order, converted based on the JSON ' +
           'representation type of the array value, as defined in this ' +
           'table.', () => {
-          expect(reserializationSuccess(value)).toBe(true);
+          expect(consume(value)).toBe(true);
         });
         it('6.2.2 JSON Consumption - JSON Array where the data model entry ' +
           'value is a set: A set, where each value of the JSON Array is ' +
           'added to the set in order, converted based on the JSON ' +
           'representation type of the array value, as defined in this ' +
           'table.', () => {
-          expect(reserializationSuccess(value)).toBe(true);
+          expect(consume(value)).toBe(true);
         });
       } else if(value !== null && typeof value === 'object') {
         it('6.2.2 JSON Consumption - JSON Object: A map, where each member ' +
@@ -35,44 +35,43 @@ const generateJsonConsumptionTests = (
           'JSON representation type as defined in this table. Since order ' +
           'is not specified by JSON Objects, no insertion order is ' +
           'guaranteed.', () => {
-          expect(reserializationSuccess(value)).toBe(true);
+          expect(consume(value)).toBe(true);
         });
       } else if(typeof value === 'string' && isXmlDatetime(value)) {
         it('6.2.2 JSON Consumption - JSON String where data model entry ' +
           'value is a datetime: A datetime.', () => {
-          expect(reserializationSuccess(value)).toBe(true);
+          expect(consume(value)).toBe(true);
         });
       } else if(typeof value === 'string') {
         it('6.2.2 JSON Consumption - JSON String, where the data model ' +
           'entry value type is string or unknown: A string.', () => {
-          expect(reserializationSuccess(value)).toBe(true);
+          expect(consume(value)).toBe(true);
         });
       } else if(typeof value === 'number') {
         if(!Number.isInteger(value)) {
           it('6.2.2 JSON Consumption - JSON Number without a decimal or ' +
             'fractional component: An integer.', () => {
-            expect(reserializationSuccess(value)).toBe(true);
+            expect(consume(value)).toBe(true);
           });
         } else {
           it('6.2.2 JSON Consumption - JSON Number with a decimal and ' +
             'fractional component, or when entry value is a double ' +
             'regardless of inclusion of fractional component: ' +
             'A double.', () => {
-            expect(reserializationSuccess(value)).toBe(true);
+            expect(consume(value)).toBe(true);
           });
         }
       } else if(typeof value === 'boolean') {
         it('6.2.2 JSON Consumption - JSON Boolean: A boolean.', () => {
-          expect(reserializationSuccess(value)).toBe(true);
+          expect(consume(value)).toBe(true);
         });
       } else if(value === null) {
         it('6.2.2 JSON Consumption - JSON null literal: A null value.', () => {
-          expect(reserializationSuccess(value)).toBe(true);
+          expect(consume(value)).toBe(true);
         });
       } else {
-        it('UNKNOWN JSON TYPE '+ value, () => {
-          expect(true).toBe(true);
-        });
+        throw new Error(
+          'Unknown application/did+json data model type for value: '+ value);
       }
     });
   });
@@ -93,9 +92,11 @@ const generateJsonConsumptionTests = (
   });
 }
 
-const reserializationSuccess = (value) => {
+const consume = (value) => {
   const reserialization = JSON.parse(JSON.stringify(value));
-  return deepEqual(value, reserialization);
+  // the next line will throw if production of the value doesn't round trip
+  expect(value).toEqual(reserialization);
+  return true;
 }
 
 const _getAllValues = (obj, results = []) => {

--- a/packages/did-core-test-server/suites/did-consumption/did-json-consumption.js
+++ b/packages/did-core-test-server/suites/did-consumption/did-json-consumption.js
@@ -1,0 +1,133 @@
+const deepEqual = require('deep-equal')
+const {isXmlDatetime} = require('../utils');
+
+const generateJsonConsumptionTests = (
+  {did, didDocumentDataModel, resolutionResult}) => {
+  const {representation} = resolutionResult;
+  const didDocument = JSON.parse(representation);
+
+  describe('6.2.2 JSON Consumption - The DID document and DID document ' +
+    'data structures JSON representation MUST be deserialized into the ' +
+    'data model according to the following consumption rules:', () => {
+    allValues = _getAllValues(didDocument);
+
+    allValues.forEach(value => {
+      if(Array.isArray(value)) {
+        it('6.2.2 JSON Consumption - JSON Array where the data model entry ' +
+          'value is a list or unknown: A list, where each value of the JSON ' +
+          'Array is added to the list in order, converted based on the JSON ' +
+          'representation type of the array value, as defined in this ' +
+          'table.', () => {
+          expect(reserializationSuccess(value)).toBe(true);
+        });
+        it('6.2.2 JSON Consumption - JSON Array where the data model entry ' +
+          'value is a set: A set, where each value of the JSON Array is ' +
+          'added to the set in order, converted based on the JSON ' +
+          'representation type of the array value, as defined in this ' +
+          'table.', () => {
+          expect(reserializationSuccess(value)).toBe(true);
+        });
+      } else if(value !== null && typeof value === 'object') {
+        it('6.2.2 JSON Consumption - JSON Object: A map, where each member ' +
+          'of the JSON Object is added as an entry to the map. Each entry ' +
+          'key is set as the JSON Object member name. Each entry value is ' +
+          'set by converting the JSON Object member value according to the ' +
+          'JSON representation type as defined in this table. Since order ' +
+          'is not specified by JSON Objects, no insertion order is ' +
+          'guaranteed.', () => {
+          expect(reserializationSuccess(value)).toBe(true);
+        });
+      } else if(typeof value === 'string' && isXmlDatetime(value)) {
+        it('6.2.2 JSON Consumption - JSON String where data model entry ' +
+          'value is a datetime: A datetime.', () => {
+          expect(reserializationSuccess(value)).toBe(true);
+        });
+      } else if(typeof value === 'string') {
+        it('6.2.2 JSON Consumption - JSON String, where the data model ' +
+          'entry value type is string or unknown: A string.', () => {
+          expect(reserializationSuccess(value)).toBe(true);
+        });
+      } else if(typeof value === 'number') {
+        if(!Number.isInteger(value)) {
+          it('6.2.2 JSON Consumption - JSON Number without a decimal or ' +
+            'fractional component: An integer.', () => {
+            expect(reserializationSuccess(value)).toBe(true);
+          });
+        } else {
+          it('6.2.2 JSON Consumption - JSON Number with a decimal and ' +
+            'fractional component, or when entry value is a double ' +
+            'regardless of inclusion of fractional component: ' +
+            'A double.', () => {
+            expect(reserializationSuccess(value)).toBe(true);
+          });
+        }
+      } else if(typeof value === 'boolean') {
+        it('6.2.2 JSON Consumption - JSON Boolean: A boolean.', () => {
+          expect(reserializationSuccess(value)).toBe(true);
+        });
+      } else if(value === null) {
+        it('6.2.2 JSON Consumption - JSON null literal: A null value.', () => {
+          expect(reserializationSuccess(value)).toBe(true);
+        });
+      } else {
+        it('UNKNOWN JSON TYPE '+ value, () => {
+          expect(true).toBe(true);
+        });
+      }
+    });
+  });
+
+  it('6.2.2 JSON Consumption - A conforming consumer for a JSON ' +
+    'representation that is consuming a DID document with a root ' +
+    'element that is not a JSON Object MUST report an error.', () => {
+    expect(typeof didDocument === 'object');
+  });
+
+  it('6.2.2 JSON Production - If media type information is available to ' +
+    'a conforming consumer and the media type value is ' +
+    'application/did+json, then the data structure being consumed is a ' +
+    'DID document, and the root element MUST be a JSON Object where all ' +
+    'members of the object are entries of the DID document.', async () => {
+      const {contentType} = resolutionResult.didResolutionMetadata;
+      expect(contentType).toBe('application/did+json');
+  });
+}
+
+const reserializationSuccess = (value) => {
+  const reserialization = JSON.parse(JSON.stringify(value));
+  return deepEqual(value, reserialization);
+}
+
+const _getAllValues = (obj, results = []) => {
+  const r = results;
+  Object.keys(obj).forEach(key => {
+    const value = obj[key];
+    r.push(value);
+    if(value !== null && typeof value === 'object') {
+     _getAllValues(value, r);
+    }
+  });
+  return r;
+};
+
+const didJsonConsumptionTests = (suiteConfig) => {
+  describe('6.2.2 JSON Consumption', () => {
+    suiteConfig.dids.forEach((did) => {
+      describe(did, () => {
+        for(const [mediaType, resolutionResult] of Object.entries(suiteConfig[did])) {
+          if(mediaType === 'application/did+json') {
+            const {didDocumentDataModel} = suiteConfig[did];
+            didDocumentDataModel.representationSpecificEntries =
+              resolutionResult.didDocumentDataModel.
+              representationSpecificEntries;
+
+            generateJsonConsumptionTests(
+              {did, didDocumentDataModel, resolutionResult});
+          }
+        }
+      });
+    });
+  });
+};
+
+module.exports = { didJsonConsumptionTests };

--- a/packages/did-core-test-server/suites/did-production/did-json-production.js
+++ b/packages/did-core-test-server/suites/did-production/did-json-production.js
@@ -19,54 +19,53 @@ const generateJsonProductionTests = (
         it('6.2.1 JSON Production - list: A JSON Array, where each element ' +
           'of the list is serialized, in order, as a value of the array ' +
           'according to its type, as defined in this table.', () => {
-          expect(serializationSuccess(value)).toBe(true);
+          expect(produce(value)).toBe(true);
         });
         it('6.2.1 JSON Production - set: A JSON Array, where each element ' +
           'of the set is added, in order, as a value of the array ' +
           'according to its type, as defined in this table.', () => {
-          expect(serializationSuccess(value)).toBe(true);
+          expect(produce(value)).toBe(true);
         });
       } else if(value !== null && typeof value === 'object') {
         it('6.2.1 JSON Production - map: A JSON Object, where each entry ' +
           'is serialized as a member of the JSON Object with the entry key ' +
           'as a JSON String member name and the entry value according to ' +
           'its type, as defined in this table.', () => {
-          expect(serializationSuccess(value)).toBe(true);
+          expect(produce(value)).toBe(true);
         });
       } else if(typeof value === 'string' && isXmlDatetime(value)) {
         it('6.2.1 JSON Production - datetime: A JSON String serialized as an ' +
           'XML Datetime normalized to UTC 00:00:00 and without sub-second ' +
           'decimal precision.', () => {
-          expect(serializationSuccess(value)).toBe(true);
+          expect(produce(value)).toBe(true);
         });
       } else if(typeof value === 'string') {
         it('6.2.1 JSON Production - string: A JSON String.', () => {
-          expect(serializationSuccess(value)).toBe(true);
+          expect(produce(value)).toBe(true);
         });
       } else if(typeof value === 'number') {
         if(!Number.isInteger(value)) {
           it('6.2.1 JSON Production - integer: A JSON Number without a ' +
             'decimal or fractional component.', () => {
-            expect(serializationSuccess(value)).toBe(true);
+            expect(produce(value)).toBe(true);
           });
         } else {
           it('6.2.1 JSON Production - double: A JSON Number with a decimal ' +
             'and fractional component.', () => {
-            expect(serializationSuccess(value)).toBe(true);
+            expect(produce(value)).toBe(true);
           });
         }
       } else if(typeof value === 'boolean') {
         it('6.2.1 JSON Production - boolean: A JSON Boolean.', () => {
-          expect(serializationSuccess(value)).toBe(true);
+          expect(produce(value)).toBe(true);
         });
       } else if(value === null) {
         it('6.2.1 JSON Production - null: A JSON null literal.', () => {
-          expect(serializationSuccess(value)).toBe(true);
+          expect(produce(value)).toBe(true);
         });
       } else {
-        it('UNKNOWN JSON TYPE '+ value, () => {
-          expect(true).toBe(true);
-        });
+        throw new Error(
+          'Unknown application/did+json data model type for value: '+ value);
       }
     });
   });
@@ -85,9 +84,11 @@ const generateJsonProductionTests = (
   });
 }
 
-const serializationSuccess = (value) => {
+const produce = (value) => {
   const reserialization = JSON.parse(JSON.stringify(value));
-  return deepEqual(value, reserialization);
+  // the next line will throw if production of the value doesn't round trip
+  expect(value).toEqual(reserialization);
+  return true;
 }
 
 const _getAllValues = (obj, results = []) => {

--- a/packages/did-core-test-server/suites/did-production/did-json-production.js
+++ b/packages/did-core-test-server/suites/did-production/did-json-production.js
@@ -26,7 +26,7 @@ const generateJsonProductionTests = (
           'according to its type, as defined in this table.', () => {
           expect(serializationSuccess(value)).toBe(true);
         });
-      } else if(typeof value === 'object') {
+      } else if(value !== null && typeof value === 'object') {
         it('6.2.1 JSON Production - map: A JSON Object, where each entry ' +
           'is serialized as a member of the JSON Object with the entry key ' +
           'as a JSON String member name and the entry value according to ' +

--- a/packages/did-core-test-server/suites/implementations/did-example-didwg.json
+++ b/packages/did-core-test-server/suites/implementations/did-example-didwg.json
@@ -44,7 +44,12 @@
         "assertionMethod": ["#key-0"],
         "capabilityInvocation": ["#key-0"],
         "capabilityDelegation": ["#key-0"],
-        "keyAgreement": ["#key-1"]
+        "keyAgreement": ["#key-1"],
+        "bespokeDatetime": "2020-09-26T20:14:02Z",
+        "bespokeDouble": 1.2,
+        "bespokeInteger": 5,
+        "bespokeBoolean": true,
+        "bespokeNull": null
       }
     },
     "application/did+json": {
@@ -52,7 +57,7 @@
         "representationSpecificEntries": {
         }
       },
-      "representation": "{\"id\":\"did:example:123\",\"verificationMethod\":[{\"id\":\"did:example:123#key-0\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:example:123\",\"publicKeyJwk\":{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"x\":\"VDXDwuGKVq91zxU6q7__jLDUq8_C5cuxECgd-1feFTE\"}},{\"id\":\"did:example:123#key-1\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:example:123\",\"publicKeyJwk\":{\"kty\":\"OKP\",\"crv\":\"X25519\",\"x\":\"3kY9jl1by7pLzgJktUH-e9H6fihdVUb00-sTzkfmIl8\"}}],\"authentication\":[\"#key-0\"],\"assertionMethod\":[\"#key-0\"],\"capabilityInvocation\":[\"#key-0\"],\"capabilityDelegation\":[\"#key-0\"],\"keyAgreement\":[\"#key-1\"]}",
+      "representation": "{\"id\":\"did:example:123\",\"verificationMethod\":[{\"id\":\"did:example:123#key-0\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:example:123\",\"publicKeyJwk\":{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"x\":\"VDXDwuGKVq91zxU6q7__jLDUq8_C5cuxECgd-1feFTE\"}},{\"id\":\"did:example:123#key-1\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:example:123\",\"publicKeyJwk\":{\"kty\":\"OKP\",\"crv\":\"X25519\",\"x\":\"3kY9jl1by7pLzgJktUH-e9H6fihdVUb00-sTzkfmIl8\"}}],\"authentication\":[\"#key-0\"],\"assertionMethod\":[\"#key-0\"],\"capabilityInvocation\":[\"#key-0\"],\"capabilityDelegation\":[\"#key-0\"],\"keyAgreement\":[\"#key-1\"],\"bespokeDatetime\":\"2020-09-26T20:14:02Z\",\"bespokeDouble\":1.2,\"bespokeInteger\":5,\"bespokeBoolean\":true,\"bespokeNull\":null}",
       "didDocumentMetadata": {
         "canonicalId": "did:example:one-two-three",
         "equivalentId": "did:example:one-two-three",
@@ -72,7 +77,7 @@
           "@context": ["https://www.w3.org/ns/did/v1"]
         }
       },
-      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\"],\"id\":\"did:example:123\",\"verificationMethod\":[{\"id\":\"did:example:123#key-0\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:example:123\",\"publicKeyJwk\":{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"x\":\"VDXDwuGKVq91zxU6q7__jLDUq8_C5cuxECgd-1feFTE\"}},{\"id\":\"did:example:123#key-1\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:example:123\",\"publicKeyJwk\":{\"kty\":\"OKP\",\"crv\":\"X25519\",\"x\":\"3kY9jl1by7pLzgJktUH-e9H6fihdVUb00-sTzkfmIl8\"}}],\"authentication\":[\"#key-0\"],\"assertionMethod\":[\"#key-0\"],\"capabilityInvocation\":[\"#key-0\"],\"capabilityDelegation\":[\"#key-0\"],\"keyAgreement\":[\"#key-1\"]}",
+      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\"],\"id\":\"did:example:123\",\"verificationMethod\":[{\"id\":\"did:example:123#key-0\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:example:123\",\"publicKeyJwk\":{\"kty\":\"OKP\",\"crv\":\"Ed25519\",\"x\":\"VDXDwuGKVq91zxU6q7__jLDUq8_C5cuxECgd-1feFTE\"}},{\"id\":\"did:example:123#key-1\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:example:123\",\"publicKeyJwk\":{\"kty\":\"OKP\",\"crv\":\"X25519\",\"x\":\"3kY9jl1by7pLzgJktUH-e9H6fihdVUb00-sTzkfmIl8\"}}],\"authentication\":[\"#key-0\"],\"assertionMethod\":[\"#key-0\"],\"capabilityInvocation\":[\"#key-0\"],\"capabilityDelegation\":[\"#key-0\"],\"keyAgreement\":[\"#key-1\"],\"bespokeDatetime\":\"2020-09-26T20:14:02Z\",\"bespokeDouble\":1.2,\"bespokeInteger\":5,\"bespokeBoolean\":true,\"bespokeNull\":null}",
       "didDocumentMetadata": {},
       "didResolutionMetadata": {
         "contentType": "application/did+ld+json"


### PR DESCRIPTION
This PR adds JSON Production and Consumption tests as well as extending `did:example` in `application/did+json` format to include all possible values in the data model (datetime, integer, double, boolean, and null).