### PR TITLE
Use jest toEqual instead of deep-equal

### DIFF
--- a/packages/did-core-test-server/package.json
+++ b/packages/did-core-test-server/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "base64url": "^3.0.1",
-    "deep-equal": "^2.0.5",
     "fastify": "^3.9.1",
     "fastify-cors": "^5.0.0",
     "fastify-swagger": "^3.5.0",

--- a/packages/did-core-test-server/suites/did-consumption/did-json-consumption.js
+++ b/packages/did-core-test-server/suites/did-consumption/did-json-consumption.js
@@ -1,4 +1,3 @@
-const deepEqual = require('deep-equal')
 const {isXmlDatetime} = require('../utils');
 
 const generateJsonConsumptionTests = (

--- a/packages/did-core-test-server/suites/did-consumption/did-jsonld-consumption.js
+++ b/packages/did-core-test-server/suites/did-consumption/did-jsonld-consumption.js
@@ -1,5 +1,3 @@
-const deepEqual = require('deep-equal')
-
 const generateJsonldConsumptionTests = (
   {did, didDocumentDataModel, resolutionResult}) => {
   const didDocument = {
@@ -13,7 +11,7 @@ const generateJsonldConsumptionTests = (
     'deserialized into the data model according to the JSON ' +
     'representation consumption rules as defined in § 6.2 JSON.', async () => {
       const consumedDidDocument = JSON.parse(representation);
-      expect(deepEqual(didDocument, consumedDidDocument)).toBe(true);
+      expect(didDocument).toEqual(consumedDidDocument);
   });
 }
 

--- a/packages/did-core-test-server/suites/did-production/did-json-production.js
+++ b/packages/did-core-test-server/suites/did-production/did-json-production.js
@@ -1,4 +1,3 @@
-const deepEqual = require('deep-equal')
 const {isXmlDatetime} = require('../utils');
 
 const generateJsonProductionTests = (

--- a/packages/did-core-test-server/suites/did-production/did-jsonld-production.js
+++ b/packages/did-core-test-server/suites/did-production/did-jsonld-production.js
@@ -1,5 +1,3 @@
-const deepEqual = require('deep-equal')
-
 const generateJsonldProductionTests = (
   {did, didDocumentDataModel, resolutionResult}) => {
   const didDocument = {
@@ -12,7 +10,7 @@ const generateJsonldProductionTests = (
     'JSON-LD representation according to the JSON representation production ' +
     'rules as defined in § 6.2 JSON.', async () => {
       reserializedDidDocument = JSON.parse(JSON.stringify(didDocument));
-      expect(deepEqual(didDocument, reserializedDidDocument)).toBe(true);
+      expect(didDocument).toEqual(reserializedDidDocument);
   });
 
   it('6.3.1 JSON-LD Production - In addition to using the JSON  ' +
@@ -33,7 +31,7 @@ const generateJsonldProductionTests = (
       } else if(Array.isArray(context)) {
         expect(context[0]).toBe('https://www.w3.org/ns/did/v1');
         reserializedContext = JSON.parse(JSON.stringify(context));
-        expect(deepEqual(context, reserializedContext)).toBe(true);
+        expect(context).toEqual(reserializedContext);
       } else {
         throw new Error('Invalid @context value '+ context);
       }

--- a/packages/did-core-test-server/suites/did-production/did-producer.js
+++ b/packages/did-core-test-server/suites/did-production/did-producer.js
@@ -1,6 +1,5 @@
 const utils = require('../utils');
 const jsonMediaTypes = ['application/did+ld+json', 'application/did+json'];
-const deepEqual = require('deep-equal')
 
 const generateDidProducerTests = (
   {did, didDocumentDataModel, resolutionResult}) => {
@@ -27,7 +26,7 @@ const generateDidProducerTests = (
       if(jsonMediaTypes.includes(contentType)) {
         const dataModel = {...dmRse, ...dmProperties};
         const parsedDataModel = JSON.parse(representation);
-        expect(deepEqual(dataModel, parsedDataModel)).toBe(true);
+        expect(dataModel).toEqual(parsedDataModel);
       } else {
         throw new Error('Unknown producer for content-type: '+ contentType);
       }
@@ -44,7 +43,7 @@ const generateDidProducerTests = (
       if(jsonMediaTypes.includes(contentType)) {
         const dataModel = {...dmRse, ...dmProperties};
         parsedDataModel = JSON.parse(JSON.stringify(dataModel));
-        expect(deepEqual(dataModel, parsedDataModel)).toBe(true);
+        expect(dataModel).toEqual(parsedDataModel);
       } else {
         throw new Error('Unknown producer for content-type: '+ contentType);
       }


### PR DESCRIPTION
Jest's [toEqual](https://jestjs.io/docs/expect#toequalvalue) matcher checks object deep equality. This PR removes the `deep-equal` dependency in favor of using the Jest matcher which may be slightly more idiomatic.