### PR TITLE
chore: Fix test for 3ID.

### DIFF
--- a/packages/did-core-test-server/suites/did-resolution/default.js
+++ b/packages/did-core-test-server/suites/did-resolution/default.js
@@ -1,8 +1,8 @@
 module.exports = {
   "name": "7.1 DID Resolution",
   "resolvers": [
-    require('../implementations/resolver-example-didwg.json')/*,
-    require('../implementations/resolver-3-3box-labs.json'),
+    require('../implementations/resolver-example-didwg.json'),
+    require('../implementations/resolver-3-3box-labs.json')/*,
     require('../implementations/resolver-ethr-consensys-mesh.json')*/
   ]
 }

--- a/packages/did-core-test-server/suites/did-url-dereferencing/default.js
+++ b/packages/did-core-test-server/suites/did-url-dereferencing/default.js
@@ -1,6 +1,7 @@
 module.exports = {
   "name": "DID URL Dereferencing",
   "dereferencers": [
-    require('../implementations/dereferencer-example-didwg.json')
+    require('../implementations/dereferencer-example-didwg.json'),
+    require('../implementations/dereferencer-3-3box-labs.json')
   ]
 }

--- a/packages/did-core-test-server/suites/implementations/dereferencer-3-3box-labs.json
+++ b/packages/did-core-test-server/suites/implementations/dereferencer-3-3box-labs.json
@@ -1,0 +1,55 @@
+{
+  "implementation": "@ceramicnetwork/3id-did-resolver",
+  "implementer": "3Box Labs",
+  "expectedOutcomes": {
+    "defaultOutcome": [ 0, 1 ],
+    "invalidDidUrlErrorOutcome": [ ],
+    "notFoundErrorOutcome": [ ]
+  },
+  "executions": [
+    {
+      "function": "dereference",
+      "input": {
+        "didUrl": "did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd?versionTime=2021-03-16T10:09:21Z",
+        "dereferenceOptions": {
+          "accept": "application/did+json"
+        }
+      },
+      "output": {
+        "dereferencingMetadata": {
+          "contentType": "application/did+json"
+        },
+        "contentStream": "{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"verificationMethod\":[{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HU1DGqXqxA2L4n2\",\"type\":\"EcdsaSecp256k1Signature2019\",\"controller\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"publicKeyBase58\":\"m1K5r87rP1JFcNGjzG2xqTPabQbPSjRUHM5jYcUu7avJ\"},{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#n7SH4mBgNemdDAQ\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"publicKeyBase58\":\"CiYaJorrKbRpkqfLcMqhgRCXZD3QeAwHQ63WBv1EuqPe\"}],\"authentication\":[{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HU1DGqXqxA2L4n2\",\"type\":\"EcdsaSecp256k1Signature2019\",\"controller\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"publicKeyBase58\":\"m1K5r87rP1JFcNGjzG2xqTPabQbPSjRUHM5jYcUu7avJ\"}],\"keyAgreement\":[{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#n7SH4mBgNemdDAQ\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"publicKeyBase58\":\"CiYaJorrKbRpkqfLcMqhgRCXZD3QeAwHQ63WBv1EuqPe\"}]}",
+        "contentMetadata": {
+          "created": "2021-03-16T10:08:21Z",
+          "nextUpdate": "2021-03-16T10:11:17Z",
+          "nextVersionId": "bafyreigxsxcy6goi2rk6pnjf3ij5quw2re2pmjpnk44bge6bb7a6borzdu",
+          "updated": "2021-03-16T10:08:21Z",
+          "versionId": "bafyreidmpfv7aumgqeqacprb2yv3t7sapsoro6dpopopyxtelknfbxifia"
+        }
+      }
+    },
+    {
+      "function": "dereference",
+      "input": {
+        "didUrl": "did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd?versionId=bafyreidmpfv7aumgqeqacprb2yv3t7sapsoro6dpopopyxtelknfbxifia",
+        "dereferenceOptions": {
+          "accept": "application/did+ld+json"
+        }
+      },
+      "output": {
+        "dereferencingMetadata": {
+          "contentType": "application/did+json"
+        },
+        "contentStream": "{\"@context\":\"https://www.w3.org/ns/did/v1\",\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"verificationMethod\":[{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HU1DGqXqxA2L4n2\",\"type\":\"EcdsaSecp256k1Signature2019\",\"controller\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"publicKeyBase58\":\"m1K5r87rP1JFcNGjzG2xqTPabQbPSjRUHM5jYcUu7avJ\"},{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#n7SH4mBgNemdDAQ\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"publicKeyBase58\":\"CiYaJorrKbRpkqfLcMqhgRCXZD3QeAwHQ63WBv1EuqPe\"}],\"authentication\":[{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HU1DGqXqxA2L4n2\",\"type\":\"EcdsaSecp256k1Signature2019\",\"controller\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"publicKeyBase58\":\"m1K5r87rP1JFcNGjzG2xqTPabQbPSjRUHM5jYcUu7avJ\"}],\"keyAgreement\":[{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#n7SH4mBgNemdDAQ\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"publicKeyBase58\":\"CiYaJorrKbRpkqfLcMqhgRCXZD3QeAwHQ63WBv1EuqPe\"}]}",
+        "contentMetadata": {
+          "created": "2021-03-16T10:08:21Z",
+          "nextUpdate": "2021-03-16T10:11:17Z",
+          "nextVersionId": "bafyreigxsxcy6goi2rk6pnjf3ij5quw2re2pmjpnk44bge6bb7a6borzdu",
+          "updated": "2021-03-16T10:08:21Z",
+          "versionId": "bafyreidmpfv7aumgqeqacprb2yv3t7sapsoro6dpopopyxtelknfbxifia"
+        }
+      }
+    }
+  ]
+}

--- a/packages/did-core-test-server/suites/implementations/resolver-3-3box-labs.json
+++ b/packages/did-core-test-server/suites/implementations/resolver-3-3box-labs.json
@@ -18,7 +18,6 @@
       },
       "output": {
         "didResolutionMetadata":{
-          "contentType":"application/did+json"
         },
         "didDocument":{
           "id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
@@ -65,116 +64,42 @@
       }
     },
     {
-      "function": "resolve",
+      "function": "resolveRepresentation",
       "input": {
-        "did": "did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd?versionTime=2021-03-16T10:09:21Z",
+        "did": "did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
         "resolutionOptions": {
+          "accept": "application/did+json"
         }
       },
       "output": {
-        "didResolutionMetadata":{
-          "contentType":"application/did+json"
+        "didResolutionMetadata": {
+          "contentType": "application/did+json"
         },
-        "didDocument":{
-          "id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-          "verificationMethod":[{
-            "id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HU1DGqXqxA2L4n2",
-            "type":"EcdsaSecp256k1Signature2019",
-            "controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-            "publicKeyBase58":"m1K5r87rP1JFcNGjzG2xqTPabQbPSjRUHM5jYcUu7avJ"
-          }, {
-            "id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#n7SH4mBgNemdDAQ",
-            "type":"X25519KeyAgreementKey2019",
-            "controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-            "publicKeyBase58":"CiYaJorrKbRpkqfLcMqhgRCXZD3QeAwHQ63WBv1EuqPe"
-          }],
-          "authentication":[{
-            "id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HU1DGqXqxA2L4n2",
-            "type":"EcdsaSecp256k1Signature2019",
-            "controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-            "publicKeyBase58":"m1K5r87rP1JFcNGjzG2xqTPabQbPSjRUHM5jYcUu7avJ"
-          }],
-          "keyAgreement":[{
-            "id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#n7SH4mBgNemdDAQ",
-            "type":"X25519KeyAgreementKey2019",
-            "controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-            "publicKeyBase58":"CiYaJorrKbRpkqfLcMqhgRCXZD3QeAwHQ63WBv1EuqPe"
-          }],
-          "publicKey":[{
-            "id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HU1DGqXqxA2L4n2",
-            "type":"EcdsaSecp256k1Signature2019",
-            "controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-            "publicKeyBase58":"m1K5r87rP1JFcNGjzG2xqTPabQbPSjRUHM5jYcUu7avJ"
-          },{
-            "id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#n7SH4mBgNemdDAQ",
-            "type":"X25519KeyAgreementKey2019",
-            "controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-            "publicKeyBase58":"CiYaJorrKbRpkqfLcMqhgRCXZD3QeAwHQ63WBv1EuqPe"
-          }]
-        },
-        "didDocumentMetadata":{
+        "didDocumentStream": "{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"verificationMethod\":[{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#aH6oxPEu6krriD6\",\"type\":\"EcdsaSecp256k1Signature2019\",\"controller\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"publicKeyBase58\":\"eHTnoNWU5ifdTsRoxGi4t13N7xTJx2EZt2dSbm5jeEMN\"},{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HWPYEjsV6rz1nB8\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"publicKeyBase58\":\"5krYs5YM6NX7VPaJ6WdxbJzsLrRAigLEfG2BzeDTJQQN\"}],\"authentication\":[{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#aH6oxPEu6krriD6\",\"type\":\"EcdsaSecp256k1Signature2019\",\"controller\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"publicKeyBase58\":\"eHTnoNWU5ifdTsRoxGi4t13N7xTJx2EZt2dSbm5jeEMN\"}],\"keyAgreement\":[{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HWPYEjsV6rz1nB8\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"publicKeyBase58\":\"5krYs5YM6NX7VPaJ6WdxbJzsLrRAigLEfG2BzeDTJQQN\"}]}",
+        "didDocumentMetadata": {
           "created": "2021-03-16T10:08:21Z",
-          "nextUpdate": "2021-03-16T10:11:17Z",
-          "nextVersionId": "bafyreigxsxcy6goi2rk6pnjf3ij5quw2re2pmjpnk44bge6bb7a6borzdu",
-          "updated": "2021-03-16T10:08:21Z",
-          "versionId": "bafyreidmpfv7aumgqeqacprb2yv3t7sapsoro6dpopopyxtelknfbxifia"
+          "updated": "2021-03-16T10:11:17Z",
+          "versionId": "bafyreigxsxcy6goi2rk6pnjf3ij5quw2re2pmjpnk44bge6bb7a6borzdu"
         }
       }
     },
     {
-      "function": "resolve",
+      "function": "resolveRepresentation",
       "input": {
-        "did": "did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd?versionId=bafyreidmpfv7aumgqeqacprb2yv3t7sapsoro6dpopopyxtelknfbxifia",
+        "did": "did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
         "resolutionOptions": {
+          "accept": "application/did+ld+json"
         }
       },
       "output": {
-        "didResolutionMetadata":{
-          "contentType":"application/did+json"
+        "didResolutionMetadata": {
+          "contentType": "application/did+ld+json"
         },
-        "didDocument":{
-          "id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-          "verificationMethod":[{
-            "id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HU1DGqXqxA2L4n2",
-            "type":"EcdsaSecp256k1Signature2019",
-            "controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-            "publicKeyBase58":"m1K5r87rP1JFcNGjzG2xqTPabQbPSjRUHM5jYcUu7avJ"
-          }, {
-            "id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#n7SH4mBgNemdDAQ",
-            "type":"X25519KeyAgreementKey2019",
-            "controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-            "publicKeyBase58":"CiYaJorrKbRpkqfLcMqhgRCXZD3QeAwHQ63WBv1EuqPe"
-          }],
-          "authentication":[{
-            "id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HU1DGqXqxA2L4n2",
-            "type":"EcdsaSecp256k1Signature2019",
-            "controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-            "publicKeyBase58":"m1K5r87rP1JFcNGjzG2xqTPabQbPSjRUHM5jYcUu7avJ"
-          }],
-          "keyAgreement":[{
-            "id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#n7SH4mBgNemdDAQ",
-            "type":"X25519KeyAgreementKey2019",
-            "controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-            "publicKeyBase58":"CiYaJorrKbRpkqfLcMqhgRCXZD3QeAwHQ63WBv1EuqPe"
-          }],
-          "publicKey":[{
-            "id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HU1DGqXqxA2L4n2",
-            "type":"EcdsaSecp256k1Signature2019",
-            "controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-            "publicKeyBase58":"m1K5r87rP1JFcNGjzG2xqTPabQbPSjRUHM5jYcUu7avJ"
-          },{
-            "id":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#n7SH4mBgNemdDAQ",
-            "type":"X25519KeyAgreementKey2019",
-            "controller":"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd",
-            "publicKeyBase58":"CiYaJorrKbRpkqfLcMqhgRCXZD3QeAwHQ63WBv1EuqPe"
-          }]
-        },
-        "didDocumentMetadata":{
+        "didDocumentStream": "{\"@context\":\"https://www.w3.org/ns/did/v1\",\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"verificationMethod\":[{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#aH6oxPEu6krriD6\",\"type\":\"EcdsaSecp256k1Signature2019\",\"controller\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"publicKeyBase58\":\"eHTnoNWU5ifdTsRoxGi4t13N7xTJx2EZt2dSbm5jeEMN\"},{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HWPYEjsV6rz1nB8\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"publicKeyBase58\":\"5krYs5YM6NX7VPaJ6WdxbJzsLrRAigLEfG2BzeDTJQQN\"}],\"authentication\":[{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#aH6oxPEu6krriD6\",\"type\":\"EcdsaSecp256k1Signature2019\",\"controller\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"publicKeyBase58\":\"eHTnoNWU5ifdTsRoxGi4t13N7xTJx2EZt2dSbm5jeEMN\"}],\"keyAgreement\":[{\"id\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd#HWPYEjsV6rz1nB8\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:3:kjzl6cwe1jw145m7jxh4jpa6iw1ps3jcjordpo81e0w04krcpz8knxvg5ygiabd\",\"publicKeyBase58\":\"5krYs5YM6NX7VPaJ6WdxbJzsLrRAigLEfG2BzeDTJQQN\"}]}",
+        "didDocumentMetadata": {
           "created": "2021-03-16T10:08:21Z",
-          "nextUpdate": "2021-03-16T10:11:17Z",
-          "nextVersionId": "bafyreigxsxcy6goi2rk6pnjf3ij5quw2re2pmjpnk44bge6bb7a6borzdu",
-          "updated": "2021-03-16T10:08:21Z",
-          "versionId": "bafyreidmpfv7aumgqeqacprb2yv3t7sapsoro6dpopopyxtelknfbxifia"
+          "updated": "2021-03-16T10:11:17Z",
+          "versionId": "bafyreigxsxcy6goi2rk6pnjf3ij5quw2re2pmjpnk44bge6bb7a6borzdu"
         }
       }
     }


### PR DESCRIPTION
This PR fixes the did-resolution test for `did:3` and moves the test vectors using DID URLs over to the dereferencer test.