### PR TITLE
Verification method to accept relative DID URL

### DIFF
--- a/packages/did-core-test-server/suites/did-core-properties/did-core-properties.js
+++ b/packages/did-core-test-server/suites/did-core-properties/did-core-properties.js
@@ -73,7 +73,8 @@ const generateDidCorePropertiesTests = (
     'Section § 3.2 DID URL Syntax.', async () => {
       const verificationMethods = getAllVerificationMethods(didDocument);
       verificationMethods.forEach(vm => {
-        expect(vm.id).toBeValidDidUrl();
+        let absoluteURL = getAbsoluteDIDURL(didDocument.id,vm.id);
+        expect(absoluteURL).toBeValidDidUrl();
       });
   });
 


### PR DESCRIPTION
This relates to the issue described in PR #120.
Relative DID URL not accepted for the id of verificatiomMethod.

Due to spec, it should support both absolute and relative.

``
The value of the id property for a verification method MUST be a string that conforms to the rules in Section § 3.2 DID URL Syntax.
``
