### PR TITLE
Fix to regexp of predicate function of toBeValidDidUrl

### DIFF
--- a/packages/jest-did-matcher/src/matchers/toBeValidDidUrl/index.test.js
+++ b/packages/jest-did-matcher/src/matchers/toBeValidDidUrl/index.test.js
@@ -11,12 +11,16 @@ describe('.toBeValidDidUrl', () => {
     ["did:example:123#ZC2jXTO6t4R501bfCXv3RxarZyUbdP2w_psLwMuY6ec"],
     ["did:example:123#keys-1"],
     ["did:example:123456/path"],
-    ["did:example:123456/path/mutiple/path"],
+    ["did:example:123456/path/multiple/path"],
+    ["did:example:123456/1path/2multiple/3path"],
+    ["did:example:123456/1-path/2-multiple/3-path"],
     ["did:example:123456/path%20with%20space"],
     ["did:example:123456?versionId=1"],
     ["did:example:123#public-key-0"],
     ["did:example:123#sig_064bebcc"],
-    ["did:example:123?service=agent&relativeRef=/credentials#degree"]
+    ["did:example:123?service=agent&relativeRef=/credentials#degree"],
+    ["did:example:abc:def-hij#klm"],
+    ["did:orb:bafkreiazah4qrybzyapmrmk2dhldz24vfmavethcrgcoq7qhic63zz55ru:EiAag4cmgxAE2isL5HG3mxjS7WRq4l-xyyTgULCAcEHQQQ#nMef0L2qNWVe8yt97ap0vH7kQK2oFdm4zkQkYL7ymOo"]
   ]).test('passes when the item is a valid DID: %s', given => {
     expect(given).toBeValidDidUrl();
   });

--- a/packages/jest-did-matcher/src/matchers/toBeValidDidUrl/predicate.js
+++ b/packages/jest-did-matcher/src/matchers/toBeValidDidUrl/predicate.js
@@ -1,15 +1,16 @@
 export default expected => {
-    const pchar = "[a-zA-Z-\\._~]|%[0-9a-fA-F]{2}|[!$&'()*+,;=:@]";
+    const pchar = "[a-zA-Z0-9\\-\\._~]|%[0-9a-fA-F]{2}|[!$&'()*+,;=:@]";
     const didUrl =
         "^" +
         "did:" +
         "([a-z0-9]+)" + // method_name
         "(:" + // method-specific-id
-           "([a-zA-Z0-9\\.\\-_]|%[0-9a-fA-F]{2})+" +
+            "([a-zA-Z0-9\\.\\-_]|%[0-9a-fA-F]{2})+" +
         ")+" +
-        "(/(" + pchar + ")*)?" // + // path-abempty
+        "((/(" + pchar + ")+)+)?" + // path-abempty
         "(\\?(" + pchar + "|/|\\?)+)?" + // [ "?" query ]
-        "(#(" + pchar + "|/|\\?)+)?" // [ "#" fragment ]
-        "$";
+        "(#(" + pchar + "|/|\\?)+)?" + // [ "#" fragment ]
+        "$"
+        ;
     return new RegExp(didUrl).test(expected);
 };


### PR DESCRIPTION
While reviewing PRs, I reviewed my code again, found the following hard-to-find bugs (sigh).

FIx to the first two errors revealed another error in the code while testing these fixed matchers with the did core test suites.

Luckily, the current tests pass as same as before applying this fix.
> did-core-test-server: Test Suites: 6 failed, 6 total
> did-core-test-server: Tests:       17 failed, 38 todo, 3200 passed, 3255 total

*** Please don't forget to `lerna run prepare` ***

---
This patch fixes multiple significant bugs in the predicate function.

- Missing multiple `+` in string concatenation of the regexp.
   Lack of `+` nullifies the effect of `$` anchor.

  This bug effectively forces the following three bugs
  to be invisible from the matcher's own tests:
  - Path segment couldn't repeat.
  - Digits were missing from pchar definition (this is huge..)
  - method-specific-id part of the pattern did not allow to use `-`

All of the above problems addressed