### PR TITLE
chore: sets the base node engine to V14 or greater

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "semi": true,
     "singleQuote": true,
     "trailingComma": "es5"
+  },
+  "engines": {
+    "node": ">=14"
   }
 }


### PR DESCRIPTION
This is useful to prevent people from encountering the same issues as what @Diiaablo95 found in issue #99