### PR TITLE
Add deno-did-pm dereference example

### DIFF
--- a/packages/did-core-test-server/suites/did-resolution/default.js
+++ b/packages/did-core-test-server/suites/did-resolution/default.js
@@ -3,6 +3,7 @@ const brokenFixtures = process.env.DID_WG_INCLUDE_BREAKING ? [
   require('../implementations/universal-resolver-did-gatc.json'),
   require('../implementations/universal-resolver-did-ccp.json'),
   require('../implementations/resolver-did-ion.json'),
+  require('../implementations/universal-resolver-did-bid.json'),
 ] : []
 
 module.exports = {
@@ -42,7 +43,7 @@ module.exports = {
     require('../implementations/resolver-nft-3box-labs.json'),
     require('../implementations/resolver-example-didwg.json'),
     require('../implementations/resolver-3-3box-labs.json'),
-    require('../implementations/universal-resolver-did-bid.json'),
+
     ...brokenFixtures
    
   ],

--- a/packages/did-core-test-server/suites/did-url-dereferencing/default.js
+++ b/packages/did-core-test-server/suites/did-url-dereferencing/default.js
@@ -7,6 +7,7 @@ module.exports = {
   "dereferencers": [
     require('../implementations/dereferencer-3-3box-labs.json'),
     require('../implementations/dereferencer-nft-3box-labs.json'),
+    require('../implementations/dereferencer-web-transmute.json'),
     ...brokenFixtures
     
   ]

--- a/packages/did-core-test-server/suites/implementations/dereferencer-web-transmute.json
+++ b/packages/did-core-test-server/suites/implementations/dereferencer-web-transmute.json
@@ -1,0 +1,27 @@
+{
+  "implementation": "https://github.com/OR13/deno-did-pm",
+  "implementer": "Transmute",
+  "expectedOutcomes": {
+    "defaultOutcome": [ 0, 1 ],
+    "invalidDidUrlErrorOutcome": [ ],
+    "notFoundErrorOutcome": [ ]
+  },
+  "executions": [
+    {
+      "function": "dereference",
+      "input": {
+        "didUrl": "did:web:or13.github.io:deno-did-pm?service=github&relativeRef=/OR13/deno-did-pm/master/docs/example-mod/mod.ts",
+        "dereferenceOptions": {
+          "accept": "application/typescript"
+        }
+      },
+      "output": {
+        "dereferencingMetadata": {
+          "contentType": "application/typescript; charset=utf-8"
+        },
+        "contentStream": "// DENO DID PM Module as:\n// http://localhost:8000/did-modules/did:web:or13.github.io:deno-did-pm?service=github&relativeRef=/OR13/deno-did-pm/master/docs/example-mod/mod.ts\n// GitHub URL as:\n// https://raw.githubusercontent.com/OR13/deno-did-pm/master/docs/example-mod/mod.ts\n\nexport const sayHello = () => {\n  console.info(\"hello\");\n};",
+        "contentMetadata": {}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR makes use of a couple rarely used did core feature:

- service
- relativeRef
- dereference (with non did core content type, in this case typescript)

The example is pulled from this did package manager for the deno programing language:

https://github.com/OR13/deno-did-pm

since deno uses URLs for modules, any deno module can be represented as a DID URL on a web origin that supports did dereferencing.

The same is likely true of GoLang as well.

