### PR TITLE
Removing `todo` test in Sec. 7.3

### DIFF
--- a/packages/did-core-test-server/suites/did-core-properties/did-metadata-structure.js
+++ b/packages/did-core-test-server/suites/did-core-properties/did-metadata-structure.js
@@ -45,16 +45,11 @@ const didMetadataStructureTests = (suiteConfig) => {
                             expect(didDocumentMetadata).toEqual(obj);
                         });
 
-                        it.todo('7.3 Metadata Structure - ' +
-                                'All metadata property definitions registered in the DID Specification Registries ' +
-                                '[DID-SPEC-REGISTRIES] MUST define the value type, including any additional formats ' +
-                                'or restrictions to that value (for example, a string formatted as a date or as a decimal integer).');
-
-                    };
+                    }
                 });
-            })
+            });
         });
-    })
+    });
 };
 
 module.exports = { didMetadataStructureTests };


### PR DESCRIPTION
As discussed in #65, removed `todo` for the following statement:
	7.3 Metadata Structure - All metadata property definitions
	registered in the DID Specification Registries
	[DID-SPEC-REGISTRIES] MUST define the value type,
	including any additional formats or restrictions to
	that value (for example, a string formatted as a date
	or as a decimal integer).