### PR TITLE
Allowing tailng pct-encoded method-specific-id

### DIFF
--- a/packages/jest-did-matcher/src/matchers/toBeValidDid/index.test.js
+++ b/packages/jest-did-matcher/src/matchers/toBeValidDid/index.test.js
@@ -12,6 +12,8 @@ describe('.toBeValidDid', () => {
     ["did:example:123456789_abcdefghi"],
     ["did:example:123456789%20abcdefghi"],
     ["did:example:123abc:123456789abcdefghi"],
+    ["did:example:abc%00"],
+    ["did:example::::::abc:::123"],
   ]).test('passes when the item is a valid DID: %s', given => {
     expect(given).toBeValidDid();
   });
@@ -28,7 +30,8 @@ describe('.not.toBeValidDid', () => {
     ["did:"],
     ["did:example"],
     ["did:example:123#ZC2jXTO6t4R501bfCXv3RxarZyUbdP2w_psLwMuY6ec"],
-    ["did:example:123#keys-1"]
+    ["did:example:123#keys-1"],
+    ["did:example:abc:::"]
   ]).test('passes when the item is not a valid DID: %s', given => {
     expect(given).not.toBeValidDid();
   });

--- a/packages/jest-did-matcher/src/matchers/toBeValidDid/predicate.js
+++ b/packages/jest-did-matcher/src/matchers/toBeValidDid/predicate.js
@@ -1,4 +1,5 @@
 export default expected => {
-    const didRegex = /^did:(?<method_name>[a-z0-9]+):(?<method_specific_id>([a-zA-Z0-9.\-_]|%[0-9a-fA-F]{2}|:)+[^:]$)/;
-    return didRegex.test(expected);
+    const didRegex1 = /^did:(?<method_name>[a-z0-9]+):(?<method_specific_id>([a-zA-Z0-9.\-_]|%[0-9a-fA-F]{2}|:)+$)/;
+    const didRegex2 = /:$/;
+    return didRegex1.test(expected) && !didRegex2.test(expected);
 };


### PR DESCRIPTION
Relates to comments in PR #101

- Adding more tests
- Replacing one regex with two simpler regexps.