### PR TITLE
Added Polygon-DID implementation Test Suites

### DIFF
--- a/packages/did-core-test-server/suites/did-consumption/default.js
+++ b/packages/did-core-test-server/suites/did-consumption/default.js
@@ -29,6 +29,7 @@ module.exports = {
     require('../implementations/did-key-mattr.json'),
     require('../implementations/did-web-mattr.json'),
     require('../implementations/did-sov-mattr.json'),
+    require('../implementations/did-polygon-ayanworks.json'),
     ...brokenFixtures
   ]
 };

--- a/packages/did-core-test-server/suites/did-core-properties/default.js
+++ b/packages/did-core-test-server/suites/did-core-properties/default.js
@@ -28,6 +28,7 @@ module.exports = {
     require('../implementations/did-key-mattr.json'),
     require('../implementations/did-web-mattr.json'),
     require('../implementations/did-sov-mattr.json'),
+    require('../implementations/did-polygon-ayanworks.json'),
     ...brokenFixtures
    
   ],

--- a/packages/did-core-test-server/suites/did-identifier/default.js
+++ b/packages/did-core-test-server/suites/did-identifier/default.js
@@ -30,6 +30,7 @@ module.exports = {
     require('../implementations/did-web-mattr.json'),
     require('../implementations/did-sov-mattr.json'),
     require('../implementations/universal-resolver-identifier-tests.json'),
+    require('../implementations/did-polygon-ayanworks.json'),
    ...brokenFixtures
   ],
 };

--- a/packages/did-core-test-server/suites/did-production/default.js
+++ b/packages/did-core-test-server/suites/did-production/default.js
@@ -29,6 +29,7 @@ module.exports = {
     require('../implementations/did-key-mattr.json'),
     require('../implementations/did-sov-mattr.json'),
     require('../implementations/did-web-mattr.json'),
+    require('../implementations/did-polygon-ayanworks.json'),
     ...brokenFixtures
   ],
 };

--- a/packages/did-core-test-server/suites/did-resolution/default.js
+++ b/packages/did-core-test-server/suites/did-resolution/default.js
@@ -47,6 +47,7 @@ module.exports = {
     require('../implementations/resolver-mattr-key.json'),
     require('../implementations/resolver-mattr-web.json'),
     require('../implementations/resolver-mattr-sov.json'),
+    require('../implementations/resolver-polygon-ayanworks.json'),
     ...brokenFixtures
    
   ],

--- a/packages/did-core-test-server/suites/did-url-dereferencing/default.js
+++ b/packages/did-core-test-server/suites/did-url-dereferencing/default.js
@@ -11,6 +11,7 @@ module.exports = {
     require('../implementations/dereferencer-web-transmute.json'),
     require('../implementations/universal-resolver-dereferencer-tests.json'),
     require('../implementations/dereferencer-mattr.json'),
+    require('../implementations/derefrencer-polygon-ayanworks.json'),
     ...brokenFixtures
     
   ]

--- a/packages/did-core-test-server/suites/implementations/dereferencer-polygon-ayanworks.json
+++ b/packages/did-core-test-server/suites/implementations/dereferencer-polygon-ayanworks.json
@@ -1,0 +1,58 @@
+{
+    "implementation": "polygon-did-dereferencer",
+    "implementer": "Ayanworks",
+    "expectedOutcomes": {
+        "defaultOutcome": [0, 1, 2, 3, 4, 5, 6],
+        "invalidDidUrlErrorOutcome": [7],
+        "notFoundErrorOutcome": [8]
+    },
+    "executions": [{
+            "function": "dereference",
+            "input": {
+                "didUrl": "did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E",
+                "dereferenceOptions": {
+                    "accept": "application/did+json"
+                }
+            },
+            "output": {
+                "dereferencingMetadata": {
+                    "contentType": "application/did+json"
+                },
+                "contentStream": "{\n\t\"@context\": \"https://w3id.org/did/v1\",\n\t\"id\": \"did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E\",\n\t\"verificationMethod\": [{\n\t\t\"id\": \"did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E\",\n\t\t\"type\": \"EcdsaSecp256k1VerificationKey2019\",\n\t\t\"controller\": \"did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E\",\n\t\t\"publicKeyBase58\": \"7Lnm1evgNdC3VNWRea5kMHqMWKDNzTbFjPLV4rtCbPHjDP29xQu58dgS5DRk9kaVzbFxFkbeWVEt5hAd5TPmXx6AHYHDw\"\n\t}]\n}",
+                "contentMetadata": {}
+            }
+        },
+        {
+            "function": "dereference",
+            "input": {
+                "didUrl": "did:polygon_3:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E",
+                "dereferenceOptions": {
+                    "accept": "application/did+json"
+                }
+            },
+            "output": {
+                "dereferencingMetadata": {
+                    "error": "invalidDidUrl"
+                },
+                "contentStream": "",
+                "contentMetadata": {}
+            }
+        },
+        {
+            "function": "dereference",
+            "input": {
+                "didUrl": "did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E",
+                "dereferenceOptions": {
+                    "accept": "application/did+ld+json"
+                }
+            },
+            "output": {
+                "dereferencingMetadata": {
+                    "error": "notFound"
+                },
+                "contentStream": "",
+                "contentMetadata": {}
+            }
+        }
+    ]
+}

--- a/packages/did-core-test-server/suites/implementations/did-polygon-ayanworks.json
+++ b/packages/did-core-test-server/suites/implementations/did-polygon-ayanworks.json
@@ -1,0 +1,34 @@
+{
+	"didMethod": "did:polygon",
+	"implementation": "https://github.com/ayanworks/polygon-did-registrar",
+	"implementer": "Ayanworks",
+	"supportedContentTypes": [
+		"application/did+json"
+	],
+	"dids": ["did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E"],
+    "didParameters": {},
+	"did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E": {
+		"didDocumentDataModel": {
+			"properties": {
+				"@context": "https://w3id.org/did/v1",
+				"id": "did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E",
+				"verificationMethod": [{
+					"id": "did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E",
+					"type": "EcdsaSecp256k1VerificationKey2019",
+					"controller": "did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E",
+					"publicKeyBase58": "7Lnm1evgNdC3VNWRea5kMHqMWKDNzTbFjPLV4rtCbPHjDP29xQu58dgS5DRk9kaVzbFxFkbeWVEt5hAd5TPmXx6AHYHDw"
+				}]
+			}
+		},
+		"application/did+json": {
+			"didDocumentDataModel": {
+				"representationSpecificEntries": {}
+			},
+			"representation": "{\n\t\"@context\": \"https://w3id.org/did/v1\",\n\t\"id\": \"did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E\",\n\t\"verificationMethod\": [{\n\t\t\"id\": \"did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E\",\n\t\t\"type\": \"EcdsaSecp256k1VerificationKey2019\",\n\t\t\"controller\": \"did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E\",\n\t\t\"publicKeyBase58\": \"7Lnm1evgNdC3VNWRea5kMHqMWKDNzTbFjPLV4rtCbPHjDP29xQu58dgS5DRk9kaVzbFxFkbeWVEt5hAd5TPmXx6AHYHDw\"\n\t}]\n}",
+			"didDocumentMetadata": {},
+            "didResolutionMetadata": {
+				"contentType": "application/did+json"
+			}
+		}
+	}
+}

--- a/packages/did-core-test-server/suites/implementations/resolver-polygon-ayanworks.json
+++ b/packages/did-core-test-server/suites/implementations/resolver-polygon-ayanworks.json
@@ -1,0 +1,33 @@
+{
+    "implementation": "https://github.com/ayanworks/polygon-did-resolver",
+    "implementer": "Ayanworks",
+    "expectedOutcomes": {
+        "defaultOutcome": [0, 1],
+        "invalidDidErrorOutcome": [],
+        "notFoundErrorOutcome": [],
+        "representationNotSupportedErrorOutcome": [],
+        "deactivatedOutcome": []
+    },
+    "executions": [{
+        "function": "resolveDid",
+        "input": {
+            "did": "did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E",
+            "resolutionOptions": {}
+        },
+        "output": {
+            "didResolutionMetadata": {
+            },
+            "didDocument": {
+                "@context": "https://w3id.org/did/v1",
+                "id": "did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E",
+                "verificationMethod": [{
+                    "id": "did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E",
+                    "type": "EcdsaSecp256k1VerificationKey2019",
+                    "controller": "did:polygon:0xBCFdE12C425E4CbDb45226Fe51F89F2d99667d3E",
+                    "publicKeyBase58": "7Lnm1evgNdC3VNWRea5kMHqMWKDNzTbFjPLV4rtCbPHjDP29xQu58dgS5DRk9kaVzbFxFkbeWVEt5hAd5TPmXx6AHYHDw"
+                }]
+            },
+            "didDocumentMetadata": {}
+        }
+    }]
+}


### PR DESCRIPTION
This request is to add test suite implementation for Polygon DID by AyanWorks.
Files added:
- did-polygon-ayanworks.json
- resolver-polygon-ayanworks.json
- derefrencer-polygon-ayanworks.json
Files edited:
packages/did-core-test-server/suites/did-consumption/default.js
packages/did-core-test-server/suites/did-core-properties/default.js
packages/did-core-test-server/suites/did-identifier/default.js
packages/did-core-test-server/suites/did-production/default.js
packages/did-core-test-server/suites/did-resolution/default.js
packages/did-core-test-server/suites/did-url-dereferencing/default.js

All the test cases pass on execution for above implementation. Please find the screenshot attached.
![Screenshot from 2021-06-30 13-59-09](https://user-images.githubusercontent.com/82880632/123928329-71fd6900-d9ab-11eb-97d1-1230e5cb3ac9.png)
