### PR TITLE
Update transmute implementation fixtures

### DIFF
--- a/packages/did-core-test-server/suites/implementations/dereferencer-web-transmute.json
+++ b/packages/did-core-test-server/suites/implementations/dereferencer-web-transmute.json
@@ -10,7 +10,7 @@
     {
       "function": "dereference",
       "input": {
-        "didUrl": "did:web:or13.github.io:deno-did-pm?service=github&relativeRef=/OR13/deno-did-pm/master/docs/example-mod/mod.ts",
+        "didUrl": "did:web:or13.github.io:deno-did-pm?service=github&relativeRef=%2FOR13%2Fdeno-did-pm%2Fmaster%2Fdocs%2Fexample-mod%2Fmod.ts",
         "dereferenceOptions": {
           "accept": "application/typescript"
         }

--- a/packages/did-core-test-server/suites/implementations/did-key-transmute.json
+++ b/packages/did-core-test-server/suites/implementations/did-key-transmute.json
@@ -7,46 +7,46 @@
     "application/did+ld+json"
   ],
   "dids": [
-    "did:key:zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4",
-    "did:key:zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9",
-    "did:key:zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr",
+    "did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv",
+    "did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9",
+    "did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7",
     "did:key:z6MkjPrEBMHGuJubLZ5HWf2jBreAuh7onKCA6BknWXYHLxjS",
     "did:key:z6LSn9Ah7d33uokFv2pg66BMN5UY72WtPE6eFjGXrA4mPcCp",
     "did:key:zQ3shwNhfEjorJrrKpqvBvNRV35NfGmVWdx2rNmQCRR58Sfpf",
     "did:key:z5TcCQtximJCYYLLmpUhydMUfyppwqQFveNQcrmLxYqbCvDrrcu9rVrHwNZEN37CWMUBRd8xgEyPighrGMMmX8NWTnSPUuWPPeFyUhLmkgA1Vqgm3eQYHF4ye7WrkB7jYcWoa68oHQNuSzw6ezgebFtt27uvJG4yjdat8Wj1e2qPMjsR63xQbmNdDTQ4zi8GDz8EwVAgu"
   ],
   "didParameters": {},
-  "did:key:zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4": {
+  "did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv": {
     "didDocumentDataModel": {
       "properties": {
-        "id": "did:key:zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4",
+        "id": "did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv",
         "verificationMethod": [
           {
-            "id": "#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4",
+            "id": "did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv",
             "type": "JsonWebKey2020",
-            "controller": "did:key:zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4",
+            "controller": "did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv",
             "publicKeyJwk": {
               "kty": "EC",
               "crv": "P-256",
-              "x": "OnGZYoDhv6aAy19vgVO9Orvm7JmMD9I3NG8I08CjOCc",
-              "y": "vQ3njX0aUGrC1WMEmIzBcMLyUzDWWMdRQQJmAbtZ9wE"
+              "x": "igrFmi0whuihKnj9R3Om1SoMph72wUGeFaBbzG2vzns",
+              "y": "efsX5b10x8yjyrj4ny3pGfLcY7Xby1KzgqOdqnsrJIM"
             }
           }
         ],
-        "authentication": [
-          "#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4"
-        ],
         "assertionMethod": [
-          "#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4"
+          "did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv"
+        ],
+        "authentication": [
+          "did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv"
         ],
         "capabilityInvocation": [
-          "#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4"
+          "did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv"
         ],
         "capabilityDelegation": [
-          "#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4"
+          "did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv"
         ],
         "keyAgreement": [
-          "#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4"
+          "did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv"
         ]
       }
     },
@@ -59,7 +59,7 @@
           ]
         }
       },
-      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"id\":\"did:key:zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4\",\"verificationMethod\":[{\"id\":\"#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:key:zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"OnGZYoDhv6aAy19vgVO9Orvm7JmMD9I3NG8I08CjOCc\",\"y\":\"vQ3njX0aUGrC1WMEmIzBcMLyUzDWWMdRQQJmAbtZ9wE\"}}],\"authentication\":[\"#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4\"],\"assertionMethod\":[\"#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4\"],\"capabilityInvocation\":[\"#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4\"],\"capabilityDelegation\":[\"#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4\"],\"keyAgreement\":[\"#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4\"]}",
+      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"id\":\"did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv\",\"verificationMethod\":[{\"id\":\"did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"igrFmi0whuihKnj9R3Om1SoMph72wUGeFaBbzG2vzns\",\"y\":\"efsX5b10x8yjyrj4ny3pGfLcY7Xby1KzgqOdqnsrJIM\"}}],\"assertionMethod\":[\"did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv\"],\"authentication\":[\"did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv\"],\"capabilityInvocation\":[\"did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv\"],\"capabilityDelegation\":[\"did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv\"],\"keyAgreement\":[\"did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv\"]}",
       "didDocumentMetadata": {},
       "didResolutionMetadata": {
         "contentType": "application/did+json"
@@ -74,44 +74,44 @@
           ]
         }
       },
-      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"id\":\"did:key:zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4\",\"verificationMethod\":[{\"id\":\"#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:key:zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"OnGZYoDhv6aAy19vgVO9Orvm7JmMD9I3NG8I08CjOCc\",\"y\":\"vQ3njX0aUGrC1WMEmIzBcMLyUzDWWMdRQQJmAbtZ9wE\"}}],\"authentication\":[\"#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4\"],\"assertionMethod\":[\"#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4\"],\"capabilityInvocation\":[\"#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4\"],\"capabilityDelegation\":[\"#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4\"],\"keyAgreement\":[\"#zXwpAQhSbCmPMVo61UAFgJjiek6t2WGJ5PMdXT5gGRYRHtyzFmxbDpQjjX5PmTT7LYKv67h8GGh2sH87ciSCCE4X5Bx4\"]}",
+      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"id\":\"did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv\",\"verificationMethod\":[{\"id\":\"did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"igrFmi0whuihKnj9R3Om1SoMph72wUGeFaBbzG2vzns\",\"y\":\"efsX5b10x8yjyrj4ny3pGfLcY7Xby1KzgqOdqnsrJIM\"}}],\"assertionMethod\":[\"did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv\"],\"authentication\":[\"did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv\"],\"capabilityInvocation\":[\"did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv\"],\"capabilityDelegation\":[\"did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv\"],\"keyAgreement\":[\"did:key:zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv#zDnaerx9CtbPJ1q36T5Ln5wYt3MQYeGRG5ehnPAmxcf5mDZpv\"]}",
       "didDocumentMetadata": {},
       "didResolutionMetadata": {
         "contentType": "application/did+ld+json"
       }
     }
   },
-  "did:key:zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9": {
+  "did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9": {
     "didDocumentDataModel": {
       "properties": {
-        "id": "did:key:zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9",
+        "id": "did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9",
         "verificationMethod": [
           {
-            "id": "#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9",
+            "id": "did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9",
             "type": "JsonWebKey2020",
-            "controller": "did:key:zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9",
+            "controller": "did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9",
             "publicKeyJwk": {
               "kty": "EC",
               "crv": "P-384",
-              "x": "U-WhMp1nS7utYTQVLidCy-PahkjafTCDVEK6bS1Hes7zrW9Xfbb6uSL5g_4M9vBm",
-              "y": "k4AyLywFzVgjtgRxViIL9YdK5NzJOgiX4gu1JvFVMuspng0oQggblASk9RlK0TGq"
+              "x": "lInTxl8fjLKp_UCrxI0WDklahi-7-_6JbtiHjiRvMvhedhKVdHBfi2HCY8t_QJyc",
+              "y": "y6N1IC-2mXxHreETBW7K3mBcw0qGr3CWHCs-yl09yCQRLcyfGv7XhqAngHOu51Zv"
             }
           }
         ],
-        "authentication": [
-          "#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9"
-        ],
         "assertionMethod": [
-          "#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9"
+          "did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9"
+        ],
+        "authentication": [
+          "did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9"
         ],
         "capabilityInvocation": [
-          "#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9"
+          "did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9"
         ],
         "capabilityDelegation": [
-          "#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9"
+          "did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9"
         ],
         "keyAgreement": [
-          "#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9"
+          "did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9"
         ]
       }
     },
@@ -124,7 +124,7 @@
           ]
         }
       },
-      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"id\":\"did:key:zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9\",\"verificationMethod\":[{\"id\":\"#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:key:zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"P-384\",\"x\":\"U-WhMp1nS7utYTQVLidCy-PahkjafTCDVEK6bS1Hes7zrW9Xfbb6uSL5g_4M9vBm\",\"y\":\"k4AyLywFzVgjtgRxViIL9YdK5NzJOgiX4gu1JvFVMuspng0oQggblASk9RlK0TGq\"}}],\"authentication\":[\"#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9\"],\"assertionMethod\":[\"#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9\"],\"capabilityInvocation\":[\"#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9\"],\"capabilityDelegation\":[\"#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9\"],\"keyAgreement\":[\"#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9\"]}",
+      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"id\":\"did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9\",\"verificationMethod\":[{\"id\":\"did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"P-384\",\"x\":\"lInTxl8fjLKp_UCrxI0WDklahi-7-_6JbtiHjiRvMvhedhKVdHBfi2HCY8t_QJyc\",\"y\":\"y6N1IC-2mXxHreETBW7K3mBcw0qGr3CWHCs-yl09yCQRLcyfGv7XhqAngHOu51Zv\"}}],\"assertionMethod\":[\"did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9\"],\"authentication\":[\"did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9\"],\"capabilityInvocation\":[\"did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9\"],\"capabilityDelegation\":[\"did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9\"],\"keyAgreement\":[\"did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9\"]}",
       "didDocumentMetadata": {},
       "didResolutionMetadata": {
         "contentType": "application/did+json"
@@ -139,44 +139,44 @@
           ]
         }
       },
-      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"id\":\"did:key:zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9\",\"verificationMethod\":[{\"id\":\"#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:key:zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"P-384\",\"x\":\"U-WhMp1nS7utYTQVLidCy-PahkjafTCDVEK6bS1Hes7zrW9Xfbb6uSL5g_4M9vBm\",\"y\":\"k4AyLywFzVgjtgRxViIL9YdK5NzJOgiX4gu1JvFVMuspng0oQggblASk9RlK0TGq\"}}],\"authentication\":[\"#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9\"],\"assertionMethod\":[\"#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9\"],\"capabilityInvocation\":[\"#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9\"],\"capabilityDelegation\":[\"#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9\"],\"keyAgreement\":[\"#zACHdCArvro31A591h98nMQa7WSJnLBeP2sF3WfntFz3F9cYuwAH49nBEQBmPvKP5rzsNLBZ4fF1N4E1Vh76qq79PLy1RjTrHuakwvZkvK7qsmKbXuMTEmhcnjbcU5UFaxmvKAC9\"]}",
+      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"id\":\"did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9\",\"verificationMethod\":[{\"id\":\"did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"P-384\",\"x\":\"lInTxl8fjLKp_UCrxI0WDklahi-7-_6JbtiHjiRvMvhedhKVdHBfi2HCY8t_QJyc\",\"y\":\"y6N1IC-2mXxHreETBW7K3mBcw0qGr3CWHCs-yl09yCQRLcyfGv7XhqAngHOu51Zv\"}}],\"assertionMethod\":[\"did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9\"],\"authentication\":[\"did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9\"],\"capabilityInvocation\":[\"did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9\"],\"capabilityDelegation\":[\"did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9\"],\"keyAgreement\":[\"did:key:z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9#z82Lm1MpAkeJcix9K8TMiLd5NMAhnwkjjCBeWHXyu3U4oT2MVJJKXkcVBgjGhnLBn2Kaau9\"]}",
       "didDocumentMetadata": {},
       "didResolutionMetadata": {
         "contentType": "application/did+ld+json"
       }
     }
   },
-  "did:key:zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr": {
+  "did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7": {
     "didDocumentDataModel": {
       "properties": {
-        "id": "did:key:zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr",
+        "id": "did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7",
         "verificationMethod": [
           {
-            "id": "#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr",
+            "id": "did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7",
             "type": "JsonWebKey2020",
-            "controller": "did:key:zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr",
+            "controller": "did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7",
             "publicKeyJwk": {
               "kty": "EC",
               "crv": "P-521",
-              "x": "APnYEpTgLtAW9p206zlHdl_twbNIi0TlhI6gpnp3LVqdOdeiCcnpvhCIb1o9OiHugccN1fIZ6zJ6A6yjOspPnP7_",
-              "y": "AFwAJijgrwEGNSN4HJ-nrlJwX0X0dnKRuarotKUOd4U-capZ65C-CfTAC84i32kogsk8jCSyL1P1eO4d0ajnpgBH"
+              "x": "ASUHPMyichQ0QbHZ9ofNx_l4y7luncn5feKLo3OpJ2nSbZoC7mffolj5uy7s6KSKXFmnNWxGJ42IOrjZ47qqwqyS",
+              "y": "AW9ziIC4ZQQVSNmLlp59yYKrjRY0_VqO-GOIYQ9tYpPraBKUloEId6cI_vynCzlZWZtWpgOM3HPhYEgawQ703RjC"
             }
           }
         ],
-        "authentication": [
-          "#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr"
-        ],
         "assertionMethod": [
-          "#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr"
+          "did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7"
+        ],
+        "authentication": [
+          "did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7"
         ],
         "capabilityInvocation": [
-          "#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr"
+          "did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7"
         ],
         "capabilityDelegation": [
-          "#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr"
+          "did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7"
         ],
         "keyAgreement": [
-          "#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr"
+          "did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7"
         ]
       }
     },
@@ -189,7 +189,7 @@
           ]
         }
       },
-      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"id\":\"did:key:zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr\",\"verificationMethod\":[{\"id\":\"#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:key:zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"P-521\",\"x\":\"APnYEpTgLtAW9p206zlHdl_twbNIi0TlhI6gpnp3LVqdOdeiCcnpvhCIb1o9OiHugccN1fIZ6zJ6A6yjOspPnP7_\",\"y\":\"AFwAJijgrwEGNSN4HJ-nrlJwX0X0dnKRuarotKUOd4U-capZ65C-CfTAC84i32kogsk8jCSyL1P1eO4d0ajnpgBH\"}}],\"authentication\":[\"#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr\"],\"assertionMethod\":[\"#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr\"],\"capabilityInvocation\":[\"#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr\"],\"capabilityDelegation\":[\"#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr\"],\"keyAgreement\":[\"#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr\"]}",
+      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"id\":\"did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7\",\"verificationMethod\":[{\"id\":\"did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"P-521\",\"x\":\"ASUHPMyichQ0QbHZ9ofNx_l4y7luncn5feKLo3OpJ2nSbZoC7mffolj5uy7s6KSKXFmnNWxGJ42IOrjZ47qqwqyS\",\"y\":\"AW9ziIC4ZQQVSNmLlp59yYKrjRY0_VqO-GOIYQ9tYpPraBKUloEId6cI_vynCzlZWZtWpgOM3HPhYEgawQ703RjC\"}}],\"assertionMethod\":[\"did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7\"],\"authentication\":[\"did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7\"],\"capabilityInvocation\":[\"did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7\"],\"capabilityDelegation\":[\"did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7\"],\"keyAgreement\":[\"did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7\"]}",
       "didDocumentMetadata": {},
       "didResolutionMetadata": {
         "contentType": "application/did+json"
@@ -204,7 +204,7 @@
           ]
         }
       },
-      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"id\":\"did:key:zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr\",\"verificationMethod\":[{\"id\":\"#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:key:zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"P-521\",\"x\":\"APnYEpTgLtAW9p206zlHdl_twbNIi0TlhI6gpnp3LVqdOdeiCcnpvhCIb1o9OiHugccN1fIZ6zJ6A6yjOspPnP7_\",\"y\":\"AFwAJijgrwEGNSN4HJ-nrlJwX0X0dnKRuarotKUOd4U-capZ65C-CfTAC84i32kogsk8jCSyL1P1eO4d0ajnpgBH\"}}],\"authentication\":[\"#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr\"],\"assertionMethod\":[\"#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr\"],\"capabilityInvocation\":[\"#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr\"],\"capabilityDelegation\":[\"#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr\"],\"keyAgreement\":[\"#zJss7xEQwMCeguBiawQPntnC4DpSgdbZxBLXb15BNT3ZLhMSyhCSUGLZf3U84xsPGtGfBnAKqtd9Sk2eAp4yBXQexiuUStFeitQvZ3as3HzYccdB7GfnRvCCcRp1T5gMTZ3r4TMc5yqihakUc6m4fRL7QCKVbScnqAqcJ3acJsyk5vH7zqvWbYUEr\"]}",
+      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/jws-2020/v1\"],\"id\":\"did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7\",\"verificationMethod\":[{\"id\":\"did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7\",\"type\":\"JsonWebKey2020\",\"controller\":\"did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"P-521\",\"x\":\"ASUHPMyichQ0QbHZ9ofNx_l4y7luncn5feKLo3OpJ2nSbZoC7mffolj5uy7s6KSKXFmnNWxGJ42IOrjZ47qqwqyS\",\"y\":\"AW9ziIC4ZQQVSNmLlp59yYKrjRY0_VqO-GOIYQ9tYpPraBKUloEId6cI_vynCzlZWZtWpgOM3HPhYEgawQ703RjC\"}}],\"assertionMethod\":[\"did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7\"],\"authentication\":[\"did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7\"],\"capabilityInvocation\":[\"did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7\"],\"capabilityDelegation\":[\"did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7\"],\"keyAgreement\":[\"did:key:z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7#z2J9gaYxrKVpdoG9A4gRnmpnRCcxU6agDtFVVBVdn1JedouoZN7SzcyREXXzWgt3gGiwpoHq7K68X4m32D8HgzG8wv3sY5j7\"]}",
       "didDocumentMetadata": {},
       "didResolutionMetadata": {
         "contentType": "application/did+ld+json"

--- a/packages/did-core-test-server/suites/implementations/did-web-transmute.json
+++ b/packages/did-core-test-server/suites/implementations/did-web-transmute.json
@@ -2,14 +2,12 @@
   "didMethod": "did:web",
   "implementation": "https://github.com/transmute-industries/did-core",
   "implementer": "Transmute",
-  "supportedContentTypes": [
-    "application/did+json",
-    "application/did+ld+json"
-  ],
-  "dids": [
-    "did:web:did.actor:mike"
-  ],
-  "didParameters": {},
+  "supportedContentTypes": ["application/did+json", "application/did+ld+json"],
+  "dids": ["did:web:did.actor:mike", "did:web:or13.github.io:deno-did-pm"],
+  "didParameters": {
+    "service": "did:web:or13.github.io:deno-did-pm?service=github&relativeRef=/OR13/deno-did-pm/master/docs/example-mod/mod.ts",
+    "relativeRef": "did:web:or13.github.io:deno-did-pm?service=github&relativeRef=/OR13/deno-did-pm/master/docs/example-mod/mod.ts"
+  },
   "did:web:did.actor:mike": {
     "didDocumentDataModel": {
       "properties": {
@@ -17,6 +15,7 @@
         "rating": 4.5,
         "publicAccess": true,
         "additionalType": null,
+        "lastCheckpoint": "2012-04-23T18:25:43.511Z",
         "verificationMethod": [
           {
             "id": "#g1",
@@ -59,12 +58,13 @@
               "@base": "did:web:did.actor:mike",
               "rating": "https://schema.org/Rating",
               "publicAccess": "https://schema.org/publicAccess",
-              "additionalType": "https://schema.org/additionalType"
+              "additionalType": "https://schema.org/additionalType",
+              "lastCheckpoint": "https://schema.org/Date"
             }
           ]
         }
       },
-      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/jws-2020/v1\",{\"@base\":\"did:web:did.actor:mike\",\"rating\":\"https://schema.org/Rating\",\"publicAccess\":\"https://schema.org/publicAccess\",\"additionalType\":\"https://schema.org/additionalType\"}],\"id\":\"did:web:did.actor:mike\",\"rating\":4.5,\"publicAccess\":true,\"additionalType\":null,\"verificationMethod\":[{\"id\":\"#g1\",\"controller\":\"did:web:did.actor:mike\",\"type\":\"JsonWebKey2020\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"BLS12381_G1\",\"x\":\"hxF12gtsn9ju4-kJq2-nUjZQKVVWpcBAYX5VHnUZMDilClZsGuOaDjlXS8pFE1GG\"}},{\"id\":\"#g2\",\"controller\":\"did:web:did.actor:mike\",\"type\":\"JsonWebKey2020\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"BLS12381_G2\",\"x\":\"l4MeBsn_OGa2OEDtHeHdq0TBC8sYh6QwoI7QsNtZk9oAru1OnGClaAPlMbvvs73EABDB6GjjzybbOHarkBmP6pon8H1VuMna0nkEYihZi8OodgdbwReDiDvWzZuXXMl-\"}}],\"authentication\":[\"did:web:did.actor:mike#g1\",\"did:web:did.actor:mike#g2\"],\"assertionMethod\":[\"did:web:did.actor:mike#g1\",\"did:web:did.actor:mike#g2\"]}",
+      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/jws-2020/v1\",{\"@base\":\"did:web:did.actor:mike\",\"rating\":\"https://schema.org/Rating\",\"publicAccess\":\"https://schema.org/publicAccess\",\"additionalType\":\"https://schema.org/additionalType\",\"lastCheckpoint\":\"https://schema.org/Date\"}],\"id\":\"did:web:did.actor:mike\",\"rating\":4.5,\"publicAccess\":true,\"additionalType\":null,\"lastCheckpoint\":\"2012-04-23T18:25:43.511Z\",\"verificationMethod\":[{\"id\":\"#g1\",\"controller\":\"did:web:did.actor:mike\",\"type\":\"JsonWebKey2020\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"BLS12381_G1\",\"x\":\"hxF12gtsn9ju4-kJq2-nUjZQKVVWpcBAYX5VHnUZMDilClZsGuOaDjlXS8pFE1GG\"}},{\"id\":\"#g2\",\"controller\":\"did:web:did.actor:mike\",\"type\":\"JsonWebKey2020\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"BLS12381_G2\",\"x\":\"l4MeBsn_OGa2OEDtHeHdq0TBC8sYh6QwoI7QsNtZk9oAru1OnGClaAPlMbvvs73EABDB6GjjzybbOHarkBmP6pon8H1VuMna0nkEYihZi8OodgdbwReDiDvWzZuXXMl-\"}}],\"authentication\":[\"did:web:did.actor:mike#g1\",\"did:web:did.actor:mike#g2\"],\"assertionMethod\":[\"did:web:did.actor:mike#g1\",\"did:web:did.actor:mike#g2\"]}",
       "didDocumentMetadata": {},
       "didResolutionMetadata": {
         "contentType": "application/did+json"
@@ -80,15 +80,67 @@
               "@base": "did:web:did.actor:mike",
               "rating": "https://schema.org/Rating",
               "publicAccess": "https://schema.org/publicAccess",
-              "additionalType": "https://schema.org/additionalType"
+              "additionalType": "https://schema.org/additionalType",
+              "lastCheckpoint": "https://schema.org/Date"
             }
           ]
         }
       },
-      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/jws-2020/v1\",{\"@base\":\"did:web:did.actor:mike\",\"rating\":\"https://schema.org/Rating\",\"publicAccess\":\"https://schema.org/publicAccess\",\"additionalType\":\"https://schema.org/additionalType\"}],\"id\":\"did:web:did.actor:mike\",\"rating\":4.5,\"publicAccess\":true,\"additionalType\":null,\"verificationMethod\":[{\"id\":\"#g1\",\"controller\":\"did:web:did.actor:mike\",\"type\":\"JsonWebKey2020\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"BLS12381_G1\",\"x\":\"hxF12gtsn9ju4-kJq2-nUjZQKVVWpcBAYX5VHnUZMDilClZsGuOaDjlXS8pFE1GG\"}},{\"id\":\"#g2\",\"controller\":\"did:web:did.actor:mike\",\"type\":\"JsonWebKey2020\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"BLS12381_G2\",\"x\":\"l4MeBsn_OGa2OEDtHeHdq0TBC8sYh6QwoI7QsNtZk9oAru1OnGClaAPlMbvvs73EABDB6GjjzybbOHarkBmP6pon8H1VuMna0nkEYihZi8OodgdbwReDiDvWzZuXXMl-\"}}],\"authentication\":[\"did:web:did.actor:mike#g1\",\"did:web:did.actor:mike#g2\"],\"assertionMethod\":[\"did:web:did.actor:mike#g1\",\"did:web:did.actor:mike#g2\"]}",
+      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/jws-2020/v1\",{\"@base\":\"did:web:did.actor:mike\",\"rating\":\"https://schema.org/Rating\",\"publicAccess\":\"https://schema.org/publicAccess\",\"additionalType\":\"https://schema.org/additionalType\",\"lastCheckpoint\":\"https://schema.org/Date\"}],\"id\":\"did:web:did.actor:mike\",\"rating\":4.5,\"publicAccess\":true,\"additionalType\":null,\"lastCheckpoint\":\"2012-04-23T18:25:43.511Z\",\"verificationMethod\":[{\"id\":\"#g1\",\"controller\":\"did:web:did.actor:mike\",\"type\":\"JsonWebKey2020\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"BLS12381_G1\",\"x\":\"hxF12gtsn9ju4-kJq2-nUjZQKVVWpcBAYX5VHnUZMDilClZsGuOaDjlXS8pFE1GG\"}},{\"id\":\"#g2\",\"controller\":\"did:web:did.actor:mike\",\"type\":\"JsonWebKey2020\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"BLS12381_G2\",\"x\":\"l4MeBsn_OGa2OEDtHeHdq0TBC8sYh6QwoI7QsNtZk9oAru1OnGClaAPlMbvvs73EABDB6GjjzybbOHarkBmP6pon8H1VuMna0nkEYihZi8OodgdbwReDiDvWzZuXXMl-\"}}],\"authentication\":[\"did:web:did.actor:mike#g1\",\"did:web:did.actor:mike#g2\"],\"assertionMethod\":[\"did:web:did.actor:mike#g1\",\"did:web:did.actor:mike#g2\"]}",
       "didDocumentMetadata": {},
       "didResolutionMetadata": {
         "contentType": "application/did+ld+json"
+      }
+    }
+  },
+  "did:web:or13.github.io:deno-did-pm": {
+    "didDocumentDataModel": {
+      "properties": {
+        "id": "did:web:or13.github.io:deno-did-pm",
+        "assertionMethod": [
+          {
+            "id": "did:web:or13.github.io:deno-did-pm#4FD4017D6188FF9B4F07299E02FECCD6306F299C",
+            "type": "PgpVerificationKey2021",
+            "controller": "did:web:or13.github.io:deno-did-pm",
+            "publicKeyPgp": "-----BEGIN PGP PUBLIC KEY BLOCK-----\r\nVersion: OpenPGP.js v4.10.9\r\nComment: https://openpgpjs.org\r\n\r\nxsBNBGAEy9sBCADPgG2ZN1sHM2UC6etMd+z94h41AJJT+ve1YX3QWuo0ZZlh\r\nktRRRPCZDWY2L4hL1IyqlWcFj8DPf5WLMEUPwJm7LGoUHZ5E+UKiP+0YYUEx\r\nV+mdD/SHx+DXV6Ji6/oU12SMlfQivFHsCzqRj8unFpp4YB4aqMPaVw4DNxx6\r\nfejnkOlIHQivvUxhIUUJPU/A7R+tQurahfMaV94JW8h0ux8zEEadLqYqKP21\r\nIMA+tSDLWj96hhWhBUu4Z1EZakTIEyTV0LniNCOn+o8hlgX5rZP6Z/lvRcoW\r\nmmHmQ+RTwLy3Uu4B8qWfxNe/X3a9jwcVrDtH1nlFiZbvgl2oK1m9wzxVABEB\r\nAAHNJWxkcy1wZ3AyMDIxIDxsZHMtcGdwMjAyMUBleGFtcGxlLmNvbT7CwKUE\r\nEwEIADgWIQRP1AF9YYj/m08HKZ4C/szWMG8pnAUCYATL2wIbAwULCQgHAgYV\r\nCgkICwIEFgIDAQIeAQIXgAAhCRAC/szWMG8pnBYhBE/UAX1hiP+bTwcpngL+\r\nzNYwbymc7bsH/2VGeS98UuZgSaTZknBiRF+EYGtSqNXQ4CWiRkN+W/5gQwcd\r\n2XjoZtW3rP4u8RlQACSXJk+GsDOGL3nbjZ6MnoLdLT2Q4dsoqIQOIiiZFZHm\r\nf4hcKAQFnpK6bDbG8wX6URQLaMc8QEnKiT4jU2N65WRXsSWaA1wQ2cpZuvSg\r\ncUlXFaoRiEq8X2PekYoTaSJYtE5LgnHHE/m7+nUK8mltjZaACPFpQd0ScKv3\r\ns/AfJb4pLvvUZasXoTX7pKSMujDn66qNuoT1wGIKKAq86w2tQi1Z9+f2JaMU\r\nSjvGQ0+gOeMK19XVvmOIkTpBKmndQ+Wb2BTdWtiTYy6mr4PHHIwRQUjOwE0E\r\nYATL2wEIANwobd+bGmq64aLPgzMuYxsTEd/nictChfPEpBAZDY13ghng6Eds\r\nNEeZHiCRI9VaIyJBLfzv1YvP8NeSaX3HVequjCfIXudOmsSBWg0q8Sj4IXcN\r\nKbBC9LP/KbEnOcUasOu0gWLESUuQ+XBWhSkDBPesD26V/u/uvImk/6SkyNcj\r\n0fUzTLt0ci1lTXVi1DOXMnvN/FnR7mp6xi2iLCzSKZK2dTKGJyQZlT1Su7X1\r\nk2IY61rQpuRsmePD3hYhaV92ZQgtTNqc8xsWOPsKW5VhZ/m2UgTg2yFPVyi9\r\nzkxiBm7GFDVmKbtUSuxKt53pvx0p1dOM4p5x4bBQXkaZYTUESn0AEQEAAcLA\r\njQQYAQgAIBYhBE/UAX1hiP+bTwcpngL+zNYwbymcBQJgBMvbAhsMACEJEAL+\r\nzNYwbymcFiEET9QBfWGI/5tPBymeAv7M1jBvKZxZdggArsGwTgOzAjC+/KPF\r\nnod6Fu2kMTGM/kelM1TzvTOFJTb2bgQiMDKvHhYjQMgSmtkws0vQQbd7O5K+\r\nzwuCL4h7wiwFQswsBdIP3SBLZh8bLGiUUp+WvBOELL1dnFN98p78UY4OhHTd\r\njSSzf0/Af7GV+pHxnAZd3x4oM2+JRz7asJKroEyeQhaZWpDpXJ0hI46k9nG8\r\n7Gs4Cp2WhrGOyen66xQoD4CHkWGc+/2FmLk/sINPTYmOqB7o9/Pcfeb+NH3G\r\n5sA/hlG+NMC3YfJaDcwX2FnqcpTSYL2bFeWOj65wAQp+9KUSNe8EveDvLO4x\r\nMRLParJJyd26xMp7bMKFpjlxCA==\r\n=NL+O\r\n-----END PGP PUBLIC KEY BLOCK-----\r\n"
+          }
+        ],
+        "service": [
+          {
+            "id": "#github",
+            "serviceEndpoint": "https://raw.githubusercontent.com"
+          }
+        ]
+      },
+      "application/did+json": {
+        "didDocumentDataModel": {
+          "representationSpecificEntries": {
+            "@context": [
+              "https://www.w3.org/ns/did/v1",
+              "https://w3id.org/security/suites/pgp-2021/v1"
+            ]
+          }
+        },
+        "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/pgp-2021/v1\"],\"id\":\"did:web:or13.github.io:deno-did-pm\",\"assertionMethod\":[{\"id\":\"did:web:or13.github.io:deno-did-pm#4FD4017D6188FF9B4F07299E02FECCD6306F299C\",\"type\":\"PgpVerificationKey2021\",\"controller\":\"did:web:or13.github.io:deno-did-pm\",\"publicKeyPgp\":\"-----BEGIN PGP PUBLIC KEY BLOCK-----\\r\\nVersion: OpenPGP.js v4.10.9\\r\\nComment: https://openpgpjs.org\\r\\n\\r\\nxsBNBGAEy9sBCADPgG2ZN1sHM2UC6etMd+z94h41AJJT+ve1YX3QWuo0ZZlh\\r\\nktRRRPCZDWY2L4hL1IyqlWcFj8DPf5WLMEUPwJm7LGoUHZ5E+UKiP+0YYUEx\\r\\nV+mdD/SHx+DXV6Ji6/oU12SMlfQivFHsCzqRj8unFpp4YB4aqMPaVw4DNxx6\\r\\nfejnkOlIHQivvUxhIUUJPU/A7R+tQurahfMaV94JW8h0ux8zEEadLqYqKP21\\r\\nIMA+tSDLWj96hhWhBUu4Z1EZakTIEyTV0LniNCOn+o8hlgX5rZP6Z/lvRcoW\\r\\nmmHmQ+RTwLy3Uu4B8qWfxNe/X3a9jwcVrDtH1nlFiZbvgl2oK1m9wzxVABEB\\r\\nAAHNJWxkcy1wZ3AyMDIxIDxsZHMtcGdwMjAyMUBleGFtcGxlLmNvbT7CwKUE\\r\\nEwEIADgWIQRP1AF9YYj/m08HKZ4C/szWMG8pnAUCYATL2wIbAwULCQgHAgYV\\r\\nCgkICwIEFgIDAQIeAQIXgAAhCRAC/szWMG8pnBYhBE/UAX1hiP+bTwcpngL+\\r\\nzNYwbymc7bsH/2VGeS98UuZgSaTZknBiRF+EYGtSqNXQ4CWiRkN+W/5gQwcd\\r\\n2XjoZtW3rP4u8RlQACSXJk+GsDOGL3nbjZ6MnoLdLT2Q4dsoqIQOIiiZFZHm\\r\\nf4hcKAQFnpK6bDbG8wX6URQLaMc8QEnKiT4jU2N65WRXsSWaA1wQ2cpZuvSg\\r\\ncUlXFaoRiEq8X2PekYoTaSJYtE5LgnHHE/m7+nUK8mltjZaACPFpQd0ScKv3\\r\\ns/AfJb4pLvvUZasXoTX7pKSMujDn66qNuoT1wGIKKAq86w2tQi1Z9+f2JaMU\\r\\nSjvGQ0+gOeMK19XVvmOIkTpBKmndQ+Wb2BTdWtiTYy6mr4PHHIwRQUjOwE0E\\r\\nYATL2wEIANwobd+bGmq64aLPgzMuYxsTEd/nictChfPEpBAZDY13ghng6Eds\\r\\nNEeZHiCRI9VaIyJBLfzv1YvP8NeSaX3HVequjCfIXudOmsSBWg0q8Sj4IXcN\\r\\nKbBC9LP/KbEnOcUasOu0gWLESUuQ+XBWhSkDBPesD26V/u/uvImk/6SkyNcj\\r\\n0fUzTLt0ci1lTXVi1DOXMnvN/FnR7mp6xi2iLCzSKZK2dTKGJyQZlT1Su7X1\\r\\nk2IY61rQpuRsmePD3hYhaV92ZQgtTNqc8xsWOPsKW5VhZ/m2UgTg2yFPVyi9\\r\\nzkxiBm7GFDVmKbtUSuxKt53pvx0p1dOM4p5x4bBQXkaZYTUESn0AEQEAAcLA\\r\\njQQYAQgAIBYhBE/UAX1hiP+bTwcpngL+zNYwbymcBQJgBMvbAhsMACEJEAL+\\r\\nzNYwbymcFiEET9QBfWGI/5tPBymeAv7M1jBvKZxZdggArsGwTgOzAjC+/KPF\\r\\nnod6Fu2kMTGM/kelM1TzvTOFJTb2bgQiMDKvHhYjQMgSmtkws0vQQbd7O5K+\\r\\nzwuCL4h7wiwFQswsBdIP3SBLZh8bLGiUUp+WvBOELL1dnFN98p78UY4OhHTd\\r\\njSSzf0/Af7GV+pHxnAZd3x4oM2+JRz7asJKroEyeQhaZWpDpXJ0hI46k9nG8\\r\\n7Gs4Cp2WhrGOyen66xQoD4CHkWGc+/2FmLk/sINPTYmOqB7o9/Pcfeb+NH3G\\r\\n5sA/hlG+NMC3YfJaDcwX2FnqcpTSYL2bFeWOj65wAQp+9KUSNe8EveDvLO4x\\r\\nMRLParJJyd26xMp7bMKFpjlxCA==\\r\\n=NL+O\\r\\n-----END PGP PUBLIC KEY BLOCK-----\\r\\n\"}],\"service\":[{\"id\":\"#github\",\"serviceEndpoint\":\"https://raw.githubusercontent.com\"}]}",
+        "didDocumentMetadata": {},
+        "didResolutionMetadata": {
+          "contentType": "application/did+json"
+        }
+      },
+      "application/did+ld+json": {
+        "didDocumentDataModel": {
+          "representationSpecificEntries": {
+            "@context": [
+              "https://www.w3.org/ns/did/v1",
+              "https://w3id.org/security/suites/pgp-2021/v1"
+            ]
+          }
+        },
+        "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/pgp-2021/v1\"],\"id\":\"did:web:or13.github.io:deno-did-pm\",\"assertionMethod\":[{\"id\":\"did:web:or13.github.io:deno-did-pm#4FD4017D6188FF9B4F07299E02FECCD6306F299C\",\"type\":\"PgpVerificationKey2021\",\"controller\":\"did:web:or13.github.io:deno-did-pm\",\"publicKeyPgp\":\"-----BEGIN PGP PUBLIC KEY BLOCK-----\\r\\nVersion: OpenPGP.js v4.10.9\\r\\nComment: https://openpgpjs.org\\r\\n\\r\\nxsBNBGAEy9sBCADPgG2ZN1sHM2UC6etMd+z94h41AJJT+ve1YX3QWuo0ZZlh\\r\\nktRRRPCZDWY2L4hL1IyqlWcFj8DPf5WLMEUPwJm7LGoUHZ5E+UKiP+0YYUEx\\r\\nV+mdD/SHx+DXV6Ji6/oU12SMlfQivFHsCzqRj8unFpp4YB4aqMPaVw4DNxx6\\r\\nfejnkOlIHQivvUxhIUUJPU/A7R+tQurahfMaV94JW8h0ux8zEEadLqYqKP21\\r\\nIMA+tSDLWj96hhWhBUu4Z1EZakTIEyTV0LniNCOn+o8hlgX5rZP6Z/lvRcoW\\r\\nmmHmQ+RTwLy3Uu4B8qWfxNe/X3a9jwcVrDtH1nlFiZbvgl2oK1m9wzxVABEB\\r\\nAAHNJWxkcy1wZ3AyMDIxIDxsZHMtcGdwMjAyMUBleGFtcGxlLmNvbT7CwKUE\\r\\nEwEIADgWIQRP1AF9YYj/m08HKZ4C/szWMG8pnAUCYATL2wIbAwULCQgHAgYV\\r\\nCgkICwIEFgIDAQIeAQIXgAAhCRAC/szWMG8pnBYhBE/UAX1hiP+bTwcpngL+\\r\\nzNYwbymc7bsH/2VGeS98UuZgSaTZknBiRF+EYGtSqNXQ4CWiRkN+W/5gQwcd\\r\\n2XjoZtW3rP4u8RlQACSXJk+GsDOGL3nbjZ6MnoLdLT2Q4dsoqIQOIiiZFZHm\\r\\nf4hcKAQFnpK6bDbG8wX6URQLaMc8QEnKiT4jU2N65WRXsSWaA1wQ2cpZuvSg\\r\\ncUlXFaoRiEq8X2PekYoTaSJYtE5LgnHHE/m7+nUK8mltjZaACPFpQd0ScKv3\\r\\ns/AfJb4pLvvUZasXoTX7pKSMujDn66qNuoT1wGIKKAq86w2tQi1Z9+f2JaMU\\r\\nSjvGQ0+gOeMK19XVvmOIkTpBKmndQ+Wb2BTdWtiTYy6mr4PHHIwRQUjOwE0E\\r\\nYATL2wEIANwobd+bGmq64aLPgzMuYxsTEd/nictChfPEpBAZDY13ghng6Eds\\r\\nNEeZHiCRI9VaIyJBLfzv1YvP8NeSaX3HVequjCfIXudOmsSBWg0q8Sj4IXcN\\r\\nKbBC9LP/KbEnOcUasOu0gWLESUuQ+XBWhSkDBPesD26V/u/uvImk/6SkyNcj\\r\\n0fUzTLt0ci1lTXVi1DOXMnvN/FnR7mp6xi2iLCzSKZK2dTKGJyQZlT1Su7X1\\r\\nk2IY61rQpuRsmePD3hYhaV92ZQgtTNqc8xsWOPsKW5VhZ/m2UgTg2yFPVyi9\\r\\nzkxiBm7GFDVmKbtUSuxKt53pvx0p1dOM4p5x4bBQXkaZYTUESn0AEQEAAcLA\\r\\njQQYAQgAIBYhBE/UAX1hiP+bTwcpngL+zNYwbymcBQJgBMvbAhsMACEJEAL+\\r\\nzNYwbymcFiEET9QBfWGI/5tPBymeAv7M1jBvKZxZdggArsGwTgOzAjC+/KPF\\r\\nnod6Fu2kMTGM/kelM1TzvTOFJTb2bgQiMDKvHhYjQMgSmtkws0vQQbd7O5K+\\r\\nzwuCL4h7wiwFQswsBdIP3SBLZh8bLGiUUp+WvBOELL1dnFN98p78UY4OhHTd\\r\\njSSzf0/Af7GV+pHxnAZd3x4oM2+JRz7asJKroEyeQhaZWpDpXJ0hI46k9nG8\\r\\n7Gs4Cp2WhrGOyen66xQoD4CHkWGc+/2FmLk/sINPTYmOqB7o9/Pcfeb+NH3G\\r\\n5sA/hlG+NMC3YfJaDcwX2FnqcpTSYL2bFeWOj65wAQp+9KUSNe8EveDvLO4x\\r\\nMRLParJJyd26xMp7bMKFpjlxCA==\\r\\n=NL+O\\r\\n-----END PGP PUBLIC KEY BLOCK-----\\r\\n\"}],\"service\":[{\"id\":\"#github\",\"serviceEndpoint\":\"https://raw.githubusercontent.com\"}]}",
+        "didDocumentMetadata": {},
+        "didResolutionMetadata": {
+          "contentType": "application/did+ld+json"
+        }
       }
     }
   }

--- a/packages/did-core-test-server/suites/implementations/did-web-transmute.json
+++ b/packages/did-core-test-server/suites/implementations/did-web-transmute.json
@@ -5,8 +5,8 @@
   "supportedContentTypes": ["application/did+json", "application/did+ld+json"],
   "dids": ["did:web:did.actor:mike", "did:web:or13.github.io:deno-did-pm"],
   "didParameters": {
-    "service": "did:web:or13.github.io:deno-did-pm?service=github&relativeRef=/OR13/deno-did-pm/master/docs/example-mod/mod.ts",
-    "relativeRef": "did:web:or13.github.io:deno-did-pm?service=github&relativeRef=/OR13/deno-did-pm/master/docs/example-mod/mod.ts"
+    "service": "did:web:or13.github.io:deno-did-pm?service=github&relativeRef=%2FOR13%2Fdeno-did-pm%2Fmaster%2Fdocs%2Fexample-mod%2Fmod.ts",
+    "relativeRef": "did:web:or13.github.io:deno-did-pm?service=github&relativeRef=%2FOR13%2Fdeno-did-pm%2Fmaster%2Fdocs%2Fexample-mod%2Fmod.ts"
   },
   "did:web:did.actor:mike": {
     "didDocumentDataModel": {
@@ -108,39 +108,40 @@
         "service": [
           {
             "id": "#github",
+            "type": "RawGitHubUserContent",
             "serviceEndpoint": "https://raw.githubusercontent.com"
           }
         ]
-      },
-      "application/did+json": {
-        "didDocumentDataModel": {
-          "representationSpecificEntries": {
-            "@context": [
-              "https://www.w3.org/ns/did/v1",
-              "https://w3id.org/security/suites/pgp-2021/v1"
-            ]
-          }
-        },
-        "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/pgp-2021/v1\"],\"id\":\"did:web:or13.github.io:deno-did-pm\",\"assertionMethod\":[{\"id\":\"did:web:or13.github.io:deno-did-pm#4FD4017D6188FF9B4F07299E02FECCD6306F299C\",\"type\":\"PgpVerificationKey2021\",\"controller\":\"did:web:or13.github.io:deno-did-pm\",\"publicKeyPgp\":\"-----BEGIN PGP PUBLIC KEY BLOCK-----\\r\\nVersion: OpenPGP.js v4.10.9\\r\\nComment: https://openpgpjs.org\\r\\n\\r\\nxsBNBGAEy9sBCADPgG2ZN1sHM2UC6etMd+z94h41AJJT+ve1YX3QWuo0ZZlh\\r\\nktRRRPCZDWY2L4hL1IyqlWcFj8DPf5WLMEUPwJm7LGoUHZ5E+UKiP+0YYUEx\\r\\nV+mdD/SHx+DXV6Ji6/oU12SMlfQivFHsCzqRj8unFpp4YB4aqMPaVw4DNxx6\\r\\nfejnkOlIHQivvUxhIUUJPU/A7R+tQurahfMaV94JW8h0ux8zEEadLqYqKP21\\r\\nIMA+tSDLWj96hhWhBUu4Z1EZakTIEyTV0LniNCOn+o8hlgX5rZP6Z/lvRcoW\\r\\nmmHmQ+RTwLy3Uu4B8qWfxNe/X3a9jwcVrDtH1nlFiZbvgl2oK1m9wzxVABEB\\r\\nAAHNJWxkcy1wZ3AyMDIxIDxsZHMtcGdwMjAyMUBleGFtcGxlLmNvbT7CwKUE\\r\\nEwEIADgWIQRP1AF9YYj/m08HKZ4C/szWMG8pnAUCYATL2wIbAwULCQgHAgYV\\r\\nCgkICwIEFgIDAQIeAQIXgAAhCRAC/szWMG8pnBYhBE/UAX1hiP+bTwcpngL+\\r\\nzNYwbymc7bsH/2VGeS98UuZgSaTZknBiRF+EYGtSqNXQ4CWiRkN+W/5gQwcd\\r\\n2XjoZtW3rP4u8RlQACSXJk+GsDOGL3nbjZ6MnoLdLT2Q4dsoqIQOIiiZFZHm\\r\\nf4hcKAQFnpK6bDbG8wX6URQLaMc8QEnKiT4jU2N65WRXsSWaA1wQ2cpZuvSg\\r\\ncUlXFaoRiEq8X2PekYoTaSJYtE5LgnHHE/m7+nUK8mltjZaACPFpQd0ScKv3\\r\\ns/AfJb4pLvvUZasXoTX7pKSMujDn66qNuoT1wGIKKAq86w2tQi1Z9+f2JaMU\\r\\nSjvGQ0+gOeMK19XVvmOIkTpBKmndQ+Wb2BTdWtiTYy6mr4PHHIwRQUjOwE0E\\r\\nYATL2wEIANwobd+bGmq64aLPgzMuYxsTEd/nictChfPEpBAZDY13ghng6Eds\\r\\nNEeZHiCRI9VaIyJBLfzv1YvP8NeSaX3HVequjCfIXudOmsSBWg0q8Sj4IXcN\\r\\nKbBC9LP/KbEnOcUasOu0gWLESUuQ+XBWhSkDBPesD26V/u/uvImk/6SkyNcj\\r\\n0fUzTLt0ci1lTXVi1DOXMnvN/FnR7mp6xi2iLCzSKZK2dTKGJyQZlT1Su7X1\\r\\nk2IY61rQpuRsmePD3hYhaV92ZQgtTNqc8xsWOPsKW5VhZ/m2UgTg2yFPVyi9\\r\\nzkxiBm7GFDVmKbtUSuxKt53pvx0p1dOM4p5x4bBQXkaZYTUESn0AEQEAAcLA\\r\\njQQYAQgAIBYhBE/UAX1hiP+bTwcpngL+zNYwbymcBQJgBMvbAhsMACEJEAL+\\r\\nzNYwbymcFiEET9QBfWGI/5tPBymeAv7M1jBvKZxZdggArsGwTgOzAjC+/KPF\\r\\nnod6Fu2kMTGM/kelM1TzvTOFJTb2bgQiMDKvHhYjQMgSmtkws0vQQbd7O5K+\\r\\nzwuCL4h7wiwFQswsBdIP3SBLZh8bLGiUUp+WvBOELL1dnFN98p78UY4OhHTd\\r\\njSSzf0/Af7GV+pHxnAZd3x4oM2+JRz7asJKroEyeQhaZWpDpXJ0hI46k9nG8\\r\\n7Gs4Cp2WhrGOyen66xQoD4CHkWGc+/2FmLk/sINPTYmOqB7o9/Pcfeb+NH3G\\r\\n5sA/hlG+NMC3YfJaDcwX2FnqcpTSYL2bFeWOj65wAQp+9KUSNe8EveDvLO4x\\r\\nMRLParJJyd26xMp7bMKFpjlxCA==\\r\\n=NL+O\\r\\n-----END PGP PUBLIC KEY BLOCK-----\\r\\n\"}],\"service\":[{\"id\":\"#github\",\"serviceEndpoint\":\"https://raw.githubusercontent.com\"}]}",
-        "didDocumentMetadata": {},
-        "didResolutionMetadata": {
-          "contentType": "application/did+json"
+      }
+    },
+    "application/did+json": {
+      "didDocumentDataModel": {
+        "representationSpecificEntries": {
+          "@context": [
+            "https://www.w3.org/ns/did/v1",
+            "https://w3id.org/security/suites/pgp-2021/v1"
+          ]
         }
       },
-      "application/did+ld+json": {
-        "didDocumentDataModel": {
-          "representationSpecificEntries": {
-            "@context": [
-              "https://www.w3.org/ns/did/v1",
-              "https://w3id.org/security/suites/pgp-2021/v1"
-            ]
-          }
-        },
-        "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/pgp-2021/v1\"],\"id\":\"did:web:or13.github.io:deno-did-pm\",\"assertionMethod\":[{\"id\":\"did:web:or13.github.io:deno-did-pm#4FD4017D6188FF9B4F07299E02FECCD6306F299C\",\"type\":\"PgpVerificationKey2021\",\"controller\":\"did:web:or13.github.io:deno-did-pm\",\"publicKeyPgp\":\"-----BEGIN PGP PUBLIC KEY BLOCK-----\\r\\nVersion: OpenPGP.js v4.10.9\\r\\nComment: https://openpgpjs.org\\r\\n\\r\\nxsBNBGAEy9sBCADPgG2ZN1sHM2UC6etMd+z94h41AJJT+ve1YX3QWuo0ZZlh\\r\\nktRRRPCZDWY2L4hL1IyqlWcFj8DPf5WLMEUPwJm7LGoUHZ5E+UKiP+0YYUEx\\r\\nV+mdD/SHx+DXV6Ji6/oU12SMlfQivFHsCzqRj8unFpp4YB4aqMPaVw4DNxx6\\r\\nfejnkOlIHQivvUxhIUUJPU/A7R+tQurahfMaV94JW8h0ux8zEEadLqYqKP21\\r\\nIMA+tSDLWj96hhWhBUu4Z1EZakTIEyTV0LniNCOn+o8hlgX5rZP6Z/lvRcoW\\r\\nmmHmQ+RTwLy3Uu4B8qWfxNe/X3a9jwcVrDtH1nlFiZbvgl2oK1m9wzxVABEB\\r\\nAAHNJWxkcy1wZ3AyMDIxIDxsZHMtcGdwMjAyMUBleGFtcGxlLmNvbT7CwKUE\\r\\nEwEIADgWIQRP1AF9YYj/m08HKZ4C/szWMG8pnAUCYATL2wIbAwULCQgHAgYV\\r\\nCgkICwIEFgIDAQIeAQIXgAAhCRAC/szWMG8pnBYhBE/UAX1hiP+bTwcpngL+\\r\\nzNYwbymc7bsH/2VGeS98UuZgSaTZknBiRF+EYGtSqNXQ4CWiRkN+W/5gQwcd\\r\\n2XjoZtW3rP4u8RlQACSXJk+GsDOGL3nbjZ6MnoLdLT2Q4dsoqIQOIiiZFZHm\\r\\nf4hcKAQFnpK6bDbG8wX6URQLaMc8QEnKiT4jU2N65WRXsSWaA1wQ2cpZuvSg\\r\\ncUlXFaoRiEq8X2PekYoTaSJYtE5LgnHHE/m7+nUK8mltjZaACPFpQd0ScKv3\\r\\ns/AfJb4pLvvUZasXoTX7pKSMujDn66qNuoT1wGIKKAq86w2tQi1Z9+f2JaMU\\r\\nSjvGQ0+gOeMK19XVvmOIkTpBKmndQ+Wb2BTdWtiTYy6mr4PHHIwRQUjOwE0E\\r\\nYATL2wEIANwobd+bGmq64aLPgzMuYxsTEd/nictChfPEpBAZDY13ghng6Eds\\r\\nNEeZHiCRI9VaIyJBLfzv1YvP8NeSaX3HVequjCfIXudOmsSBWg0q8Sj4IXcN\\r\\nKbBC9LP/KbEnOcUasOu0gWLESUuQ+XBWhSkDBPesD26V/u/uvImk/6SkyNcj\\r\\n0fUzTLt0ci1lTXVi1DOXMnvN/FnR7mp6xi2iLCzSKZK2dTKGJyQZlT1Su7X1\\r\\nk2IY61rQpuRsmePD3hYhaV92ZQgtTNqc8xsWOPsKW5VhZ/m2UgTg2yFPVyi9\\r\\nzkxiBm7GFDVmKbtUSuxKt53pvx0p1dOM4p5x4bBQXkaZYTUESn0AEQEAAcLA\\r\\njQQYAQgAIBYhBE/UAX1hiP+bTwcpngL+zNYwbymcBQJgBMvbAhsMACEJEAL+\\r\\nzNYwbymcFiEET9QBfWGI/5tPBymeAv7M1jBvKZxZdggArsGwTgOzAjC+/KPF\\r\\nnod6Fu2kMTGM/kelM1TzvTOFJTb2bgQiMDKvHhYjQMgSmtkws0vQQbd7O5K+\\r\\nzwuCL4h7wiwFQswsBdIP3SBLZh8bLGiUUp+WvBOELL1dnFN98p78UY4OhHTd\\r\\njSSzf0/Af7GV+pHxnAZd3x4oM2+JRz7asJKroEyeQhaZWpDpXJ0hI46k9nG8\\r\\n7Gs4Cp2WhrGOyen66xQoD4CHkWGc+/2FmLk/sINPTYmOqB7o9/Pcfeb+NH3G\\r\\n5sA/hlG+NMC3YfJaDcwX2FnqcpTSYL2bFeWOj65wAQp+9KUSNe8EveDvLO4x\\r\\nMRLParJJyd26xMp7bMKFpjlxCA==\\r\\n=NL+O\\r\\n-----END PGP PUBLIC KEY BLOCK-----\\r\\n\"}],\"service\":[{\"id\":\"#github\",\"serviceEndpoint\":\"https://raw.githubusercontent.com\"}]}",
-        "didDocumentMetadata": {},
-        "didResolutionMetadata": {
-          "contentType": "application/did+ld+json"
+      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/pgp-2021/v1\"],\"id\":\"did:web:or13.github.io:deno-did-pm\",\"assertionMethod\":[{\"id\":\"did:web:or13.github.io:deno-did-pm#4FD4017D6188FF9B4F07299E02FECCD6306F299C\",\"type\":\"PgpVerificationKey2021\",\"controller\":\"did:web:or13.github.io:deno-did-pm\",\"publicKeyPgp\":\"-----BEGIN PGP PUBLIC KEY BLOCK-----\\r\\nVersion: OpenPGP.js v4.10.9\\r\\nComment: https://openpgpjs.org\\r\\n\\r\\nxsBNBGAEy9sBCADPgG2ZN1sHM2UC6etMd+z94h41AJJT+ve1YX3QWuo0ZZlh\\r\\nktRRRPCZDWY2L4hL1IyqlWcFj8DPf5WLMEUPwJm7LGoUHZ5E+UKiP+0YYUEx\\r\\nV+mdD/SHx+DXV6Ji6/oU12SMlfQivFHsCzqRj8unFpp4YB4aqMPaVw4DNxx6\\r\\nfejnkOlIHQivvUxhIUUJPU/A7R+tQurahfMaV94JW8h0ux8zEEadLqYqKP21\\r\\nIMA+tSDLWj96hhWhBUu4Z1EZakTIEyTV0LniNCOn+o8hlgX5rZP6Z/lvRcoW\\r\\nmmHmQ+RTwLy3Uu4B8qWfxNe/X3a9jwcVrDtH1nlFiZbvgl2oK1m9wzxVABEB\\r\\nAAHNJWxkcy1wZ3AyMDIxIDxsZHMtcGdwMjAyMUBleGFtcGxlLmNvbT7CwKUE\\r\\nEwEIADgWIQRP1AF9YYj/m08HKZ4C/szWMG8pnAUCYATL2wIbAwULCQgHAgYV\\r\\nCgkICwIEFgIDAQIeAQIXgAAhCRAC/szWMG8pnBYhBE/UAX1hiP+bTwcpngL+\\r\\nzNYwbymc7bsH/2VGeS98UuZgSaTZknBiRF+EYGtSqNXQ4CWiRkN+W/5gQwcd\\r\\n2XjoZtW3rP4u8RlQACSXJk+GsDOGL3nbjZ6MnoLdLT2Q4dsoqIQOIiiZFZHm\\r\\nf4hcKAQFnpK6bDbG8wX6URQLaMc8QEnKiT4jU2N65WRXsSWaA1wQ2cpZuvSg\\r\\ncUlXFaoRiEq8X2PekYoTaSJYtE5LgnHHE/m7+nUK8mltjZaACPFpQd0ScKv3\\r\\ns/AfJb4pLvvUZasXoTX7pKSMujDn66qNuoT1wGIKKAq86w2tQi1Z9+f2JaMU\\r\\nSjvGQ0+gOeMK19XVvmOIkTpBKmndQ+Wb2BTdWtiTYy6mr4PHHIwRQUjOwE0E\\r\\nYATL2wEIANwobd+bGmq64aLPgzMuYxsTEd/nictChfPEpBAZDY13ghng6Eds\\r\\nNEeZHiCRI9VaIyJBLfzv1YvP8NeSaX3HVequjCfIXudOmsSBWg0q8Sj4IXcN\\r\\nKbBC9LP/KbEnOcUasOu0gWLESUuQ+XBWhSkDBPesD26V/u/uvImk/6SkyNcj\\r\\n0fUzTLt0ci1lTXVi1DOXMnvN/FnR7mp6xi2iLCzSKZK2dTKGJyQZlT1Su7X1\\r\\nk2IY61rQpuRsmePD3hYhaV92ZQgtTNqc8xsWOPsKW5VhZ/m2UgTg2yFPVyi9\\r\\nzkxiBm7GFDVmKbtUSuxKt53pvx0p1dOM4p5x4bBQXkaZYTUESn0AEQEAAcLA\\r\\njQQYAQgAIBYhBE/UAX1hiP+bTwcpngL+zNYwbymcBQJgBMvbAhsMACEJEAL+\\r\\nzNYwbymcFiEET9QBfWGI/5tPBymeAv7M1jBvKZxZdggArsGwTgOzAjC+/KPF\\r\\nnod6Fu2kMTGM/kelM1TzvTOFJTb2bgQiMDKvHhYjQMgSmtkws0vQQbd7O5K+\\r\\nzwuCL4h7wiwFQswsBdIP3SBLZh8bLGiUUp+WvBOELL1dnFN98p78UY4OhHTd\\r\\njSSzf0/Af7GV+pHxnAZd3x4oM2+JRz7asJKroEyeQhaZWpDpXJ0hI46k9nG8\\r\\n7Gs4Cp2WhrGOyen66xQoD4CHkWGc+/2FmLk/sINPTYmOqB7o9/Pcfeb+NH3G\\r\\n5sA/hlG+NMC3YfJaDcwX2FnqcpTSYL2bFeWOj65wAQp+9KUSNe8EveDvLO4x\\r\\nMRLParJJyd26xMp7bMKFpjlxCA==\\r\\n=NL+O\\r\\n-----END PGP PUBLIC KEY BLOCK-----\\r\\n\"}],\"service\":[{\"id\":\"#github\",\"type\":\"RawGitHubUserContent\", \"serviceEndpoint\":\"https://raw.githubusercontent.com\"}]}",
+      "didDocumentMetadata": {},
+      "didResolutionMetadata": {
+        "contentType": "application/did+json"
+      }
+    },
+    "application/did+ld+json": {
+      "didDocumentDataModel": {
+        "representationSpecificEntries": {
+          "@context": [
+            "https://www.w3.org/ns/did/v1",
+            "https://w3id.org/security/suites/pgp-2021/v1"
+          ]
         }
+      },
+      "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://w3id.org/security/suites/pgp-2021/v1\"],\"id\":\"did:web:or13.github.io:deno-did-pm\",\"assertionMethod\":[{\"id\":\"did:web:or13.github.io:deno-did-pm#4FD4017D6188FF9B4F07299E02FECCD6306F299C\",\"type\":\"PgpVerificationKey2021\",\"controller\":\"did:web:or13.github.io:deno-did-pm\",\"publicKeyPgp\":\"-----BEGIN PGP PUBLIC KEY BLOCK-----\\r\\nVersion: OpenPGP.js v4.10.9\\r\\nComment: https://openpgpjs.org\\r\\n\\r\\nxsBNBGAEy9sBCADPgG2ZN1sHM2UC6etMd+z94h41AJJT+ve1YX3QWuo0ZZlh\\r\\nktRRRPCZDWY2L4hL1IyqlWcFj8DPf5WLMEUPwJm7LGoUHZ5E+UKiP+0YYUEx\\r\\nV+mdD/SHx+DXV6Ji6/oU12SMlfQivFHsCzqRj8unFpp4YB4aqMPaVw4DNxx6\\r\\nfejnkOlIHQivvUxhIUUJPU/A7R+tQurahfMaV94JW8h0ux8zEEadLqYqKP21\\r\\nIMA+tSDLWj96hhWhBUu4Z1EZakTIEyTV0LniNCOn+o8hlgX5rZP6Z/lvRcoW\\r\\nmmHmQ+RTwLy3Uu4B8qWfxNe/X3a9jwcVrDtH1nlFiZbvgl2oK1m9wzxVABEB\\r\\nAAHNJWxkcy1wZ3AyMDIxIDxsZHMtcGdwMjAyMUBleGFtcGxlLmNvbT7CwKUE\\r\\nEwEIADgWIQRP1AF9YYj/m08HKZ4C/szWMG8pnAUCYATL2wIbAwULCQgHAgYV\\r\\nCgkICwIEFgIDAQIeAQIXgAAhCRAC/szWMG8pnBYhBE/UAX1hiP+bTwcpngL+\\r\\nzNYwbymc7bsH/2VGeS98UuZgSaTZknBiRF+EYGtSqNXQ4CWiRkN+W/5gQwcd\\r\\n2XjoZtW3rP4u8RlQACSXJk+GsDOGL3nbjZ6MnoLdLT2Q4dsoqIQOIiiZFZHm\\r\\nf4hcKAQFnpK6bDbG8wX6URQLaMc8QEnKiT4jU2N65WRXsSWaA1wQ2cpZuvSg\\r\\ncUlXFaoRiEq8X2PekYoTaSJYtE5LgnHHE/m7+nUK8mltjZaACPFpQd0ScKv3\\r\\ns/AfJb4pLvvUZasXoTX7pKSMujDn66qNuoT1wGIKKAq86w2tQi1Z9+f2JaMU\\r\\nSjvGQ0+gOeMK19XVvmOIkTpBKmndQ+Wb2BTdWtiTYy6mr4PHHIwRQUjOwE0E\\r\\nYATL2wEIANwobd+bGmq64aLPgzMuYxsTEd/nictChfPEpBAZDY13ghng6Eds\\r\\nNEeZHiCRI9VaIyJBLfzv1YvP8NeSaX3HVequjCfIXudOmsSBWg0q8Sj4IXcN\\r\\nKbBC9LP/KbEnOcUasOu0gWLESUuQ+XBWhSkDBPesD26V/u/uvImk/6SkyNcj\\r\\n0fUzTLt0ci1lTXVi1DOXMnvN/FnR7mp6xi2iLCzSKZK2dTKGJyQZlT1Su7X1\\r\\nk2IY61rQpuRsmePD3hYhaV92ZQgtTNqc8xsWOPsKW5VhZ/m2UgTg2yFPVyi9\\r\\nzkxiBm7GFDVmKbtUSuxKt53pvx0p1dOM4p5x4bBQXkaZYTUESn0AEQEAAcLA\\r\\njQQYAQgAIBYhBE/UAX1hiP+bTwcpngL+zNYwbymcBQJgBMvbAhsMACEJEAL+\\r\\nzNYwbymcFiEET9QBfWGI/5tPBymeAv7M1jBvKZxZdggArsGwTgOzAjC+/KPF\\r\\nnod6Fu2kMTGM/kelM1TzvTOFJTb2bgQiMDKvHhYjQMgSmtkws0vQQbd7O5K+\\r\\nzwuCL4h7wiwFQswsBdIP3SBLZh8bLGiUUp+WvBOELL1dnFN98p78UY4OhHTd\\r\\njSSzf0/Af7GV+pHxnAZd3x4oM2+JRz7asJKroEyeQhaZWpDpXJ0hI46k9nG8\\r\\n7Gs4Cp2WhrGOyen66xQoD4CHkWGc+/2FmLk/sINPTYmOqB7o9/Pcfeb+NH3G\\r\\n5sA/hlG+NMC3YfJaDcwX2FnqcpTSYL2bFeWOj65wAQp+9KUSNe8EveDvLO4x\\r\\nMRLParJJyd26xMp7bMKFpjlxCA==\\r\\n=NL+O\\r\\n-----END PGP PUBLIC KEY BLOCK-----\\r\\n\"}],\"service\":[{\"id\":\"#github\",\"type\":\"RawGitHubUserContent\", \"serviceEndpoint\":\"https://raw.githubusercontent.com\"}]}",
+      "didDocumentMetadata": {},
+      "didResolutionMetadata": {
+        "contentType": "application/did+ld+json"
       }
     }
   }


### PR DESCRIPTION
@msporny I attempted to update our examples to get things to render better.

The dereference tests were not parsing the didUrls, so adding examples of did params to our `did:web` implementation uncovered bugs that the dereference tests by themselves did not catch.

This suggestions that we really ought to either:

1. update the dereference tests so they fail when did url parsing fails.
2.  require implementers to submit ALL did url examples they use in `resolve or dereference fixtures` in their `did implementation fixture`

I took the option 2 approach, here... IMO, option 1 would be better.

cc @peacekeeper 