### PR TITLE
feat: update report for MATTR implementations

### DIFF
--- a/packages/did-core-test-server/suites/implementations/dereferencer-mattr.json
+++ b/packages/did-core-test-server/suites/implementations/dereferencer-mattr.json
@@ -3,8 +3,15 @@
     "implementer": "MATTR Limited",
     "expectedOutcomes": {
         "defaultOutcome": [0, 1, 2, 3, 4, 5, 6],
-        "invalidDidUrlErrorOutcome": [7],
-        "notFoundErrorOutcome": [8]
+        "invalidDidUrlErrorOutcome": [10],
+        "notFoundErrorOutcome": [7, 8, 9, 11]
+    },
+    "didParameters": {
+        "hl": "did:web:kyledenhartog.com?hl=zQmWvQxTqbG2Z9HPJgG57jjwR154cKhbtJenbyYTWkjgF3e",
+        "service": "did:web:kyledenhartog.com?service=dogPicService",
+        "relativeRef": "did:web:kyledenhartog.com?service=dogPicService&relativeRef=KW6NCtG.jpg",
+        "versionId": "did:web:kyledenhartog.com?versionId=1",
+        "versionTime": "did:web:kyledenhartog.com?versionTime=2020-09-26T20:14:02Z"
     },
     "executions": [{
         "function": "dereference",
@@ -15,7 +22,7 @@
             }
         },
         "output": {
-            "contentStream": "{\"@context\":[\"https://w3.org/ns/did/v1\",\"https://kyledenhartog/context/doggoservice\",\"https://www.w3id.org/security/suites/ed25519-2018/v1\",\"https://www.w3id.org/security/suites/x25519-2019/v1\"],\"id\":\"did:web:kyledenhartog.com\",\"verificationMethod\":[{\"id\":\"#signingKey\",\"type\":\"Ed25519VerificationKey2018\",\"controller\":\"did:web:kyledenhartog.com\",\"publicKeyBase58\":\"AywtfWyMWRTokKnnwLChyCDMM32sbLzcGFxuuxKtwmxH\"},{\"id\":\"did:web:kyledenhartog.com#handshakeKey\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:web:kyledenhartog.com\",\"publicKeyBase58\":\"trJuKT83nv2FruwDkmMD5945R1syU5sCDiLm4kr2mTj\"},{\"id\":\"/pathHandshakeKey\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:key:z6MkuQCtdrrbS1iyN1MXJgUxNtZv4Qi5M1p5m7aFmHo3AQXD\",\"publicKeyBase58\":\"5YLjenFRbMKCHV9HsFWhYbmxUnVnuEQxREwYvmRcLpX7\"}],\"authentication\":[\"did:web:kyledenhartog.com#signingKey\"],\"assertionMethod\":[\"did:web:kyledenhartog.com#signingKey\",{\"id\":\"did:web:kyledenhartog.com/fullyQualifiedPathSigningKey\",\"type\":\"Ed25519VerificationKey2018\",\"controller\":\"did:key:z6MkuQCtdrrbS1iyN1MXJgUxNtZv4Qi5M1p5m7aFmHo3AQXD\",\"publicKeyBase58\":\"Fwwr3ccA6UEWFWWpd7X7Xo1vEqSDw8Zj56fKw1q2FBjq\"}],\"capabilityDelegation\":[\"did:web:kyledenhartog.com#signingKey\"],\"capabilityInvocation\":[\"did:web:kyledenhartog.com#signingKey\"],\"keyAgreement\":[\"did:web:kyledenhartog.com#handshakeKey\",\"/pathHandshakeKey\"],\"service\":[{\"id\":\"did:web:kyledenhartog.com#dogPicService\",\"type\":\"DogPicService\",\"serviceEndpoint\":\"https://i.imgur.com\"}]}",
+            "contentStream": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://kyledenhartog.com/context/doggoservice.json\",\"https://www.w3id.org/security/suites/ed25519-2018/v1\",\"https://www.w3id.org/security/suites/x25519-2019/v1\"],\"id\":\"did:web:kyledenhartog.com\",\"verificationMethod\":[{\"id\":\"#signingKey\",\"type\":\"Ed25519VerificationKey2018\",\"controller\":\"did:web:kyledenhartog.com\",\"publicKeyBase58\":\"AywtfWyMWRTokKnnwLChyCDMM32sbLzcGFxuuxKtwmxH\"},{\"id\":\"did:web:kyledenhartog.com#handshakeKey\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:web:kyledenhartog.com\",\"publicKeyBase58\":\"trJuKT83nv2FruwDkmMD5945R1syU5sCDiLm4kr2mTj\"},{\"id\":\"/pathHandshakeKey\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:key:z6MkuQCtdrrbS1iyN1MXJgUxNtZv4Qi5M1p5m7aFmHo3AQXD\",\"publicKeyBase58\":\"5YLjenFRbMKCHV9HsFWhYbmxUnVnuEQxREwYvmRcLpX7\"}],\"authentication\":[\"did:web:kyledenhartog.com#signingKey\"],\"assertionMethod\":[\"did:web:kyledenhartog.com#signingKey\",{\"id\":\"did:web:kyledenhartog.com/fullyQualifiedPathSigningKey\",\"type\":\"Ed25519VerificationKey2018\",\"controller\":\"did:key:z6MkuQCtdrrbS1iyN1MXJgUxNtZv4Qi5M1p5m7aFmHo3AQXD\",\"publicKeyBase58\":\"Fwwr3ccA6UEWFWWpd7X7Xo1vEqSDw8Zj56fKw1q2FBjq\"}],\"capabilityDelegation\":[\"did:web:kyledenhartog.com#signingKey\"],\"capabilityInvocation\":[\"did:web:kyledenhartog.com#signingKey\"],\"keyAgreement\":[\"did:web:kyledenhartog.com#handshakeKey\",\"/pathHandshakeKey\"],\"service\":[{\"id\":\"did:web:kyledenhartog.com#dogPicService\",\"type\":\"DogPicService\",\"serviceEndpoint\":\"https://i.imgur.com\"}]}",
             "dereferencingMetadata": {
                 "contentType": "application/did+json"
             },
@@ -108,6 +115,51 @@
             "contentStream": "https://i.imgur.com/KW6NCtG.jpg",
             "dereferencingMetadata": {
                 "contentType": "text/url"
+            },
+            "contentMetadata": {}
+        }
+    }, {
+        "function": "dereference",
+        "input": {
+            "didUrl": "did:web:kyledenhartog.com?hl=zQmWvQxTqbG2Z9HPJgG57jjwR154cKhbtJenbyYTWkjgF3e",
+            "dereferenceOptions": {
+                "accept": "application/did+json"
+            }
+        },
+        "output": {
+            "contentStream": "",
+            "dereferencingMetadata": {
+                "error": "notFound"
+            },
+            "contentMetadata": {}
+        }
+    }, {
+        "function": "dereference",
+        "input": {
+            "didUrl": "did:web:kyledenhartog.com?versionId=1",
+            "dereferenceOptions": {
+                "accept": "application/did+json"
+            }
+        },
+        "output": {
+            "contentStream": "",
+            "dereferencingMetadata": {
+                "error": "notFound"
+            },
+            "contentMetadata": {}
+        }
+    }, {
+        "function": "dereference",
+        "input": {
+            "didUrl": "did:web:kyledenhartog.com?versionTime=2020-09-26T20:14:02Z",
+            "dereferenceOptions": {
+                "accept": "application/did+json"
+            }
+        },
+        "output": {
+            "contentStream": "",
+            "dereferencingMetadata": {
+                "error": "notFound"
             },
             "contentMetadata": {}
         }

--- a/packages/did-core-test-server/suites/implementations/did-key-mattr.json
+++ b/packages/did-core-test-server/suites/implementations/did-key-mattr.json
@@ -2,12 +2,12 @@
     "didMethod": "did:key",
     "implementation": "MATTR Internal Libraries",
     "implementer": "MATTR Limited",
-    "supportedContentTypes": ["application/did+ld+json"],
+    "supportedContentTypes": ["application/did+ld+json", "application/did+json"],
     "dids": ["did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH", "did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV"],
     "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH": {
         "didDocumentDataModel": {
             "properties": {
-                "@context": "https://www.w3.org/ns/did/v1",
+                "@context": ["https://www.w3.org/ns/did/v1", "https://www.w3id.org/security/suites/ed25519-2018/v1", "https://www.w3id.org/security/suites/x25519-2019/v1"],
                 "id": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
                 "publicKey": [{
                     "id": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
@@ -30,20 +30,30 @@
         "application/did+ld+json": {
             "didDocumentDataModel": {
                 "representationSpecificEntries": {
-                    "@context": "https://www.w3.org/ns/did/v1"
+                    "@context": ["https://www.w3.org/ns/did/v1", "https://www.w3id.org/security/suites/ed25519-2018/v1", "https://www.w3id.org/security/suites/x25519-2019/v1"]
                 }
             },
-            "representation": "{\"@context\":\"https://www.w3.org/ns/did/v1\",\"id\":\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\",\"publicKey\":[{\"id\":\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\",\"type\":\"Ed25519VerificationKey2018\",\"controller\":\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\",\"publicKeyBase58\":\"B12NYF8RrR3h41TDCTJojY59usg3mbtbjnFs7Eud1Y6u\"}],\"authentication\":[\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\"],\"assertionMethod\":[\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\"],\"capabilityDelegation\":[\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\"],\"capabilityInvocation\":[\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\"],\"keyAgreement\":[{\"id\":\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\",\"publicKeyBase58\":\"JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr\"}]}",
+            "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://www.w3id.org/security/suites/ed25519-2018/v1\",\"https://www.w3id.org/security/suites/x25519-2019/v1\"],\"id\":\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\",\"publicKey\":[{\"id\":\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\",\"type\":\"Ed25519VerificationKey2018\",\"controller\":\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\",\"publicKeyBase58\":\"B12NYF8RrR3h41TDCTJojY59usg3mbtbjnFs7Eud1Y6u\"}],\"authentication\":[\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\"],\"assertionMethod\":[\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\"],\"capabilityDelegation\":[\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\"],\"capabilityInvocation\":[\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\"],\"keyAgreement\":[{\"id\":\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\",\"publicKeyBase58\":\"JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr\"}]}",
             "didDocumentMetadata": {},
             "didResolutionMetadata": {
                 "contentType": "application/did+ld+json"
+            }
+        },
+        "application/did+json": {
+            "didDocumentDataModel": {
+                "representationSpecificEntries": {}
+            },
+            "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://www.w3id.org/security/suites/ed25519-2018/v1\",\"https://www.w3id.org/security/suites/x25519-2019/v1\"],\"id\":\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\",\"publicKey\":[{\"id\":\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\",\"type\":\"Ed25519VerificationKey2018\",\"controller\":\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\",\"publicKeyBase58\":\"B12NYF8RrR3h41TDCTJojY59usg3mbtbjnFs7Eud1Y6u\"}],\"authentication\":[\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\"],\"assertionMethod\":[\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\"],\"capabilityDelegation\":[\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\"],\"capabilityInvocation\":[\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\"],\"keyAgreement\":[{\"id\":\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH\",\"publicKeyBase58\":\"JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr\"}]}",
+            "didDocumentMetadata": {},
+            "didResolutionMetadata": {
+                "contentType": "application/did+json"
             }
         }
     },
     "did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV": {
         "didDocumentDataModel": {
             "properties": {
-                "@context": "https://www.w3.org/ns/did/v1",
+                "@context": ["https://www.w3.org/ns/did/v1", "https://www.w3id.org/security/bbs/v1"],
                 "id": "did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV",
                 "publicKey": [{
                     "id": "did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV#zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV",
@@ -60,13 +70,23 @@
         "application/did+ld+json": {
             "didDocumentDataModel": {
                 "representationSpecificEntries": {
-                    "@context": "https://www.w3.org/ns/did/v1"
+                    "@context": ["https://www.w3.org/ns/did/v1", "https://www.w3id.org/security/bbs/v1"]
                 }
             },
-            "representation": "{\"@context\":\"https://www.w3.org/ns/did/v1\",\"id\":\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\",\"publicKey\":[{\"id\":\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV#zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\",\"type\":\"Bls12381G2Key2020\",\"controller\":\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\",\"publicKeyBase58\":\"26kzHLo5a6sa6ZmyUsgGcJKo6ATCRosLKUqDXwpc31gXc6puDvPwBgke83dji5egouTxU3kUuQNX9zJqfvETgDDH2ttFjrfXDFQjtjeaRzKSHY9eQwT4AApbgimG6m9JspAB\"}],\"authentication\":[\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV#zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\"],\"assertionMethod\":[\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV#zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\"],\"capabilityDelegation\":[\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV#zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\"],\"capabilityInvocation\":[\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV#zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\"]}",
+            "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://www.w3id.org/security/bbs/v1\"],\"id\":\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\",\"publicKey\":[{\"id\":\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV#zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\",\"type\":\"Bls12381G2Key2020\",\"controller\":\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\",\"publicKeyBase58\":\"26kzHLo5a6sa6ZmyUsgGcJKo6ATCRosLKUqDXwpc31gXc6puDvPwBgke83dji5egouTxU3kUuQNX9zJqfvETgDDH2ttFjrfXDFQjtjeaRzKSHY9eQwT4AApbgimG6m9JspAB\"}],\"authentication\":[\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV#zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\"],\"assertionMethod\":[\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV#zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\"],\"capabilityDelegation\":[\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV#zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\"],\"capabilityInvocation\":[\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV#zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\"]}",
             "didDocumentMetadata": {},
             "didResolutionMetadata": {
                 "contentType": "application/did+ld+json"
+            }
+        },
+        "application/did+json": {
+            "didDocumentDataModel": {
+                "representationSpecificEntries": {}
+            },
+            "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://www.w3id.org/security/bbs/v1\"],\"id\":\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\",\"publicKey\":[{\"id\":\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV#zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\",\"type\":\"Bls12381G2Key2020\",\"controller\":\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\",\"publicKeyBase58\":\"26kzHLo5a6sa6ZmyUsgGcJKo6ATCRosLKUqDXwpc31gXc6puDvPwBgke83dji5egouTxU3kUuQNX9zJqfvETgDDH2ttFjrfXDFQjtjeaRzKSHY9eQwT4AApbgimG6m9JspAB\"}],\"authentication\":[\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV#zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\"],\"assertionMethod\":[\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV#zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\"],\"capabilityDelegation\":[\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV#zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\"],\"capabilityInvocation\":[\"did:key:zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV#zUC7LbYAQUjoTVSJyieL3cxpbdA1QjWdqqtFMDoMRg4qkZtQWRrrd4LLVCboCd5xbxET3gNM6ALinG57wBZo5VoQ3AokhE9qpJehX4SHdsDJUGa9u3z22PEGLd1fBwzzLhTkJmV\"]}",
+            "didDocumentMetadata": {},
+            "didResolutionMetadata": {
+                "contentType": "application/did+json"
             }
         }
     }

--- a/packages/did-core-test-server/suites/implementations/did-sov-mattr.json
+++ b/packages/did-core-test-server/suites/implementations/did-sov-mattr.json
@@ -2,28 +2,27 @@
     "didMethod": "did:sov",
     "implementation": "MATTR Internal Libraries",
     "implementer": "MATTR Limited",
-    "supportedContentTypes": ["application/did+ld+json"],
-    "dids": ["did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV"],
-    "did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV": {
+    "supportedContentTypes": ["application/did+ld+json", "application/did+json"],
+    "did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP": {
         "didDocumentDataModel": {
             "properties": {
                 "@context": "https://www.w3.org/ns/did/v1",
-                "id": "did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV",
-                "assertionMethod": ["did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV#GWg6D3Vct2"],
-                "authentication": ["did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV#GWg6D3Vct2"],
-                "capabilityDelegation": ["did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV#GWg6D3Vct2"],
-                "capabilityInvocation": ["did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV#GWg6D3Vct2"],
+                "id": "did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP",
+                "assertionMethod": ["did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#5j8n1udfzW"],
+                "authentication": ["did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#5j8n1udfzW"],
+                "capabilityDelegation": ["did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#5j8n1udfzW"],
+                "capabilityInvocation": ["did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#5j8n1udfzW"],
                 "keyAgreement": [{
-                    "id": "did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV#GoqUPBC3Tc",
+                    "id": "did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#DPVUftknVe",
                     "type": "X25519KeyAgreementKey2019",
-                    "controller": "did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV",
-                    "publicKeyBase58": "GoqUPBC3TceCXgPyPtnMrKEwZpqQe8eiVcoWyi5wg6w2"
+                    "controller": "did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP",
+                    "publicKeyBase58": "DPVUftknVeH6pndT81shhT1dtqNALTbzk9J3NDZEdZP1"
                 }],
                 "publicKey": [{
-                    "id": "did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV#GWg6D3Vct2",
+                    "id": "did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#5j8n1udfzW",
                     "type": "Ed25519VerificationKey2018",
-                    "controller": "did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV",
-                    "publicKeyBase58": "GWg6D3Vct2XdD73Juf85hstsTgPFPSEXWosPYZ6hatDx"
+                    "controller": "did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP",
+                    "publicKeyBase58": "5j8n1udfzW5X6cYnk15pi5e1Xo3sPJd9SVUukvGzVjCq"
                 }]
             }
         },
@@ -33,11 +32,22 @@
                     "@context": "https://www.w3.org/ns/did/v1"
                 }
             },
-            "representation": "{\"@context\":\"https://www.w3.org/ns/did/v1\",\"id\":\"did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV\",\"assertionMethod\":[\"did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV#GWg6D3Vct2\"],\"authentication\":[\"did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV#GWg6D3Vct2\"],\"capabilityDelegation\":[\"did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV#GWg6D3Vct2\"],\"capabilityInvocation\":[\"did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV#GWg6D3Vct2\"],\"keyAgreement\":[{\"id\":\"did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV#GoqUPBC3Tc\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV\",\"publicKeyBase58\":\"GoqUPBC3TceCXgPyPtnMrKEwZpqQe8eiVcoWyi5wg6w2\"}],\"publicKey\":[{\"id\":\"did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV#GWg6D3Vct2\",\"type\":\"Ed25519VerificationKey2018\",\"controller\":\"did:sov:mattr-dev:9bpZcycJ1BamZ6NyjXi4EV\",\"publicKeyBase58\":\"GWg6D3Vct2XdD73Juf85hstsTgPFPSEXWosPYZ6hatDx\"}]}",
+            "representation": "{\"@context\":\"https://www.w3.org/ns/did/v1\",\"id\":\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP\",\"assertionMethod\":[\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#5j8n1udfzW\"],\"authentication\":[\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#5j8n1udfzW\"],\"capabilityDelegation\":[\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#5j8n1udfzW\"],\"capabilityInvocation\":[\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#5j8n1udfzW\"],\"keyAgreement\":[{\"id\":\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#DPVUftknVe\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP\",\"publicKeyBase58\":\"DPVUftknVeH6pndT81shhT1dtqNALTbzk9J3NDZEdZP1\"}],\"publicKey\":[{\"id\":\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#5j8n1udfzW\",\"type\":\"Ed25519VerificationKey2018\",\"controller\":\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP\",\"publicKeyBase58\":\"5j8n1udfzW5X6cYnk15pi5e1Xo3sPJd9SVUukvGzVjCq\"}]}",
             "didDocumentMetadata": {},
             "didResolutionMetadata": {
                 "contentType": "application/did+ld+json"
             }
+        },
+        "application/did+json": {
+            "didDocumentDataModel": {
+                "representationSpecificEntries": {}
+            },
+            "representation": "{\"@context\":\"https://www.w3.org/ns/did/v1\",\"id\":\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP\",\"assertionMethod\":[\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#5j8n1udfzW\"],\"authentication\":[\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#5j8n1udfzW\"],\"capabilityDelegation\":[\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#5j8n1udfzW\"],\"capabilityInvocation\":[\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#5j8n1udfzW\"],\"keyAgreement\":[{\"id\":\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#DPVUftknVe\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP\",\"publicKeyBase58\":\"DPVUftknVeH6pndT81shhT1dtqNALTbzk9J3NDZEdZP1\"}],\"publicKey\":[{\"id\":\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP#5j8n1udfzW\",\"type\":\"Ed25519VerificationKey2018\",\"controller\":\"did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP\",\"publicKeyBase58\":\"5j8n1udfzW5X6cYnk15pi5e1Xo3sPJd9SVUukvGzVjCq\"}]}",
+            "didDocumentMetadata": {},
+            "didResolutionMetadata": {
+                "contentType": "application/did+json"
+            }
         }
-    }
+    },
+    "dids": ["did:sov:mattr-dev:3WhAjtBidfhGbiAyNQBxPP"]
 }

--- a/packages/did-core-test-server/suites/implementations/did-web-mattr.json
+++ b/packages/did-core-test-server/suites/implementations/did-web-mattr.json
@@ -1,16 +1,8 @@
 {
-    "didMethod": "did:web:did.actor:healthcare:doctor:robert",
+    "didMethod": "did:web",
     "implementation": "MATTR Internal Libraries",
     "implementer": "MATTR Limited",
-    "supportedContentTypes": ["application/did+ld+json"],
-    "dids": ["did:web:did.actor:healthcare:doctor:robert"],
-    "didParameters": {
-        "hl": "did:web:did.actor:healthcare:doctor:robert?hl=zQmWvQxTqbG2Z9HPJgG57jjwR154cKhbtJenbyYTWkjgF3e",
-        "service": "did:web:did.actor:healthcare:doctor:robert?service=agent&relativeRef=%2Fpath%2Fto%2Fresource",
-        "relativeRef": "did:web:did.actor:healthcare:doctor:robert?service=agent&relativeRef=%2Fpath%2Fto%2Fresource",
-        "versionId": "did:web:did.actor:healthcare:doctor:robert?versionId=0.1.0",
-        "versionTime": "did:web:did.actor:healthcare:doctor:robert?versionTime=2020-09-26T20:14:02Z"
-    },
+    "supportedContentTypes": ["application/did+ld+json", "application/did+json"],
     "did:web:did.actor:healthcare:doctor:robert": {
         "didDocumentDataModel": {
             "properties": {
@@ -42,6 +34,142 @@
             "didResolutionMetadata": {
                 "contentType": "application/did+ld+json"
             }
+        },
+        "application/did+json": {
+            "didDocumentDataModel": {
+                "representationSpecificEntries": {}
+            },
+            "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\"],\"id\":\"did:web:did.actor:healthcare:doctor:robert\",\"verificationMethod\":[{\"id\":\"#g1\",\"type\":\"Bls12381G1Key2020\",\"controller\":\"did:web:did.actor:healthcare:doctor:robert\",\"publicKeyBase58\":\"6RC6BhU93EFEbdqBE43KTmeTraiTLw6ukAFJH3sTavrzpKfFAXKxKKud4cy2KeDLpH\"},{\"id\":\"#g2\",\"type\":\"Bls12381G2Key2020\",\"controller\":\"did:web:did.actor:healthcare:doctor:robert\",\"publicKeyBase58\":\"25TLkGwTeWqQZ1mVpJCzRPFUvvs1y3o9EeDUNE19S65uVkSubBf3cHDxa7wXG5TSnYXHJhmDfmjbsdu1ZnWs3rceY7bGwAeDjdk8XqwoMrff3svgpUzwqHqX53crLQtCQUcS\"}],\"authentication\":[\"#g1\",\"#g2\"],\"assertionMethod\":[\"#g1\",\"#g2\"]}",
+            "didDocumentMetadata": {},
+            "didResolutionMetadata": {
+                "contentType": "application/did+json"
+            }
         }
-    }
+    },
+    "did:web:did.actor:mike": {
+        "didDocumentDataModel": {
+            "properties": {
+                "@context": ["https://www.w3.org/ns/did/v1", {
+                    "@base": "did:web:did.actor:mike",
+                    "rating": "https://schema.org/Rating",
+                    "publicAccess": "https://schema.org/publicAccess",
+                    "additionalType": "https://schema.org/additionalType"
+                }],
+                "id": "did:web:did.actor:mike",
+                "rating": 4.5,
+                "publicAccess": true,
+                "additionalType": null,
+                "verificationMethod": [{
+                    "id": "#g1",
+                    "controller": "did:web:did.actor:mike",
+                    "type": "JsonWebKey2020",
+                    "publicKeyJwk": {
+                        "kty": "EC",
+                        "crv": "BLS12381_G1",
+                        "x": "hxF12gtsn9ju4-kJq2-nUjZQKVVWpcBAYX5VHnUZMDilClZsGuOaDjlXS8pFE1GG"
+                    }
+                }, {
+                    "id": "#g2",
+                    "controller": "did:web:did.actor:mike",
+                    "type": "JsonWebKey2020",
+                    "publicKeyJwk": {
+                        "kty": "EC",
+                        "crv": "BLS12381_G2",
+                        "x": "l4MeBsn_OGa2OEDtHeHdq0TBC8sYh6QwoI7QsNtZk9oAru1OnGClaAPlMbvvs73EABDB6GjjzybbOHarkBmP6pon8H1VuMna0nkEYihZi8OodgdbwReDiDvWzZuXXMl-"
+                    }
+                }],
+                "authentication": ["did:web:did.actor:mike#g1", "did:web:did.actor:mike#g2"],
+                "assertionMethod": ["did:web:did.actor:mike#g1", "did:web:did.actor:mike#g2"]
+            }
+        },
+        "application/did+ld+json": {
+            "didDocumentDataModel": {
+                "representationSpecificEntries": {
+                    "@context": ["https://www.w3.org/ns/did/v1", {
+                        "@base": "did:web:did.actor:mike",
+                        "rating": "https://schema.org/Rating",
+                        "publicAccess": "https://schema.org/publicAccess",
+                        "additionalType": "https://schema.org/additionalType"
+                    }]
+                }
+            },
+            "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",{\"@base\":\"did:web:did.actor:mike\",\"rating\":\"https://schema.org/Rating\",\"publicAccess\":\"https://schema.org/publicAccess\",\"additionalType\":\"https://schema.org/additionalType\"}],\"id\":\"did:web:did.actor:mike\",\"rating\":4.5,\"publicAccess\":true,\"additionalType\":null,\"verificationMethod\":[{\"id\":\"#g1\",\"controller\":\"did:web:did.actor:mike\",\"type\":\"JsonWebKey2020\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"BLS12381_G1\",\"x\":\"hxF12gtsn9ju4-kJq2-nUjZQKVVWpcBAYX5VHnUZMDilClZsGuOaDjlXS8pFE1GG\"}},{\"id\":\"#g2\",\"controller\":\"did:web:did.actor:mike\",\"type\":\"JsonWebKey2020\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"BLS12381_G2\",\"x\":\"l4MeBsn_OGa2OEDtHeHdq0TBC8sYh6QwoI7QsNtZk9oAru1OnGClaAPlMbvvs73EABDB6GjjzybbOHarkBmP6pon8H1VuMna0nkEYihZi8OodgdbwReDiDvWzZuXXMl-\"}}],\"authentication\":[\"did:web:did.actor:mike#g1\",\"did:web:did.actor:mike#g2\"],\"assertionMethod\":[\"did:web:did.actor:mike#g1\",\"did:web:did.actor:mike#g2\"]}",
+            "didDocumentMetadata": {},
+            "didResolutionMetadata": {
+                "contentType": "application/did+ld+json"
+            }
+        },
+        "application/did+json": {
+            "didDocumentDataModel": {
+                "representationSpecificEntries": {}
+            },
+            "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",{\"@base\":\"did:web:did.actor:mike\",\"rating\":\"https://schema.org/Rating\",\"publicAccess\":\"https://schema.org/publicAccess\",\"additionalType\":\"https://schema.org/additionalType\"}],\"id\":\"did:web:did.actor:mike\",\"rating\":4.5,\"publicAccess\":true,\"additionalType\":null,\"verificationMethod\":[{\"id\":\"#g1\",\"controller\":\"did:web:did.actor:mike\",\"type\":\"JsonWebKey2020\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"BLS12381_G1\",\"x\":\"hxF12gtsn9ju4-kJq2-nUjZQKVVWpcBAYX5VHnUZMDilClZsGuOaDjlXS8pFE1GG\"}},{\"id\":\"#g2\",\"controller\":\"did:web:did.actor:mike\",\"type\":\"JsonWebKey2020\",\"publicKeyJwk\":{\"kty\":\"EC\",\"crv\":\"BLS12381_G2\",\"x\":\"l4MeBsn_OGa2OEDtHeHdq0TBC8sYh6QwoI7QsNtZk9oAru1OnGClaAPlMbvvs73EABDB6GjjzybbOHarkBmP6pon8H1VuMna0nkEYihZi8OodgdbwReDiDvWzZuXXMl-\"}}],\"authentication\":[\"did:web:did.actor:mike#g1\",\"did:web:did.actor:mike#g2\"],\"assertionMethod\":[\"did:web:did.actor:mike#g1\",\"did:web:did.actor:mike#g2\"]}",
+            "didDocumentMetadata": {},
+            "didResolutionMetadata": {
+                "contentType": "application/did+json"
+            }
+        }
+    },
+    "did:web:kyledenhartog.com": {
+        "didDocumentDataModel": {
+            "properties": {
+                "@context": ["https://www.w3.org/ns/did/v1", "https://kyledenhartog/context/doggoservice", "https://www.w3id.org/security/suites/ed25519-2018/v1", "https://www.w3id.org/security/suites/x25519-2019/v1"],
+                "id": "did:web:kyledenhartog.com",
+                "verificationMethod": [{
+                    "id": "#signingKey",
+                    "type": "Ed25519VerificationKey2018",
+                    "controller": "did:web:kyledenhartog.com",
+                    "publicKeyBase58": "AywtfWyMWRTokKnnwLChyCDMM32sbLzcGFxuuxKtwmxH"
+                }, {
+                    "id": "did:web:kyledenhartog.com#handshakeKey",
+                    "type": "X25519KeyAgreementKey2019",
+                    "controller": "did:web:kyledenhartog.com",
+                    "publicKeyBase58": "trJuKT83nv2FruwDkmMD5945R1syU5sCDiLm4kr2mTj"
+                }, {
+                    "id": "/pathHandshakeKey",
+                    "type": "X25519KeyAgreementKey2019",
+                    "controller": "did:key:z6MkuQCtdrrbS1iyN1MXJgUxNtZv4Qi5M1p5m7aFmHo3AQXD",
+                    "publicKeyBase58": "5YLjenFRbMKCHV9HsFWhYbmxUnVnuEQxREwYvmRcLpX7"
+                }],
+                "authentication": ["did:web:kyledenhartog.com#signingKey"],
+                "assertionMethod": ["did:web:kyledenhartog.com#signingKey", {
+                    "id": "did:web:kyledenhartog.com/fullyQualifiedPathSigningKey",
+                    "type": "Ed25519VerificationKey2018",
+                    "controller": "did:key:z6MkuQCtdrrbS1iyN1MXJgUxNtZv4Qi5M1p5m7aFmHo3AQXD",
+                    "publicKeyBase58": "Fwwr3ccA6UEWFWWpd7X7Xo1vEqSDw8Zj56fKw1q2FBjq"
+                }],
+                "capabilityDelegation": ["did:web:kyledenhartog.com#signingKey"],
+                "capabilityInvocation": ["did:web:kyledenhartog.com#signingKey"],
+                "keyAgreement": ["did:web:kyledenhartog.com#handshakeKey", "/pathHandshakeKey"],
+                "service": [{
+                    "id": "did:web:kyledenhartog.com#dogPicService",
+                    "type": "DogPicService",
+                    "serviceEndpoint": "https://i.imgur.com"
+                }]
+            }
+        },
+        "application/did+ld+json": {
+            "didDocumentDataModel": {
+                "representationSpecificEntries": {
+                    "@context": ["https://www.w3.org/ns/did/v1", "https://kyledenhartog/context/doggoservice", "https://www.w3id.org/security/suites/ed25519-2018/v1", "https://www.w3id.org/security/suites/x25519-2019/v1"]
+                }
+            },
+            "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://kyledenhartog/context/doggoservice\",\"https://www.w3id.org/security/suites/ed25519-2018/v1\",\"https://www.w3id.org/security/suites/x25519-2019/v1\"],\"id\":\"did:web:kyledenhartog.com\",\"verificationMethod\":[{\"id\":\"#signingKey\",\"type\":\"Ed25519VerificationKey2018\",\"controller\":\"did:web:kyledenhartog.com\",\"publicKeyBase58\":\"AywtfWyMWRTokKnnwLChyCDMM32sbLzcGFxuuxKtwmxH\"},{\"id\":\"did:web:kyledenhartog.com#handshakeKey\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:web:kyledenhartog.com\",\"publicKeyBase58\":\"trJuKT83nv2FruwDkmMD5945R1syU5sCDiLm4kr2mTj\"},{\"id\":\"/pathHandshakeKey\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:key:z6MkuQCtdrrbS1iyN1MXJgUxNtZv4Qi5M1p5m7aFmHo3AQXD\",\"publicKeyBase58\":\"5YLjenFRbMKCHV9HsFWhYbmxUnVnuEQxREwYvmRcLpX7\"}],\"authentication\":[\"did:web:kyledenhartog.com#signingKey\"],\"assertionMethod\":[\"did:web:kyledenhartog.com#signingKey\",{\"id\":\"did:web:kyledenhartog.com/fullyQualifiedPathSigningKey\",\"type\":\"Ed25519VerificationKey2018\",\"controller\":\"did:key:z6MkuQCtdrrbS1iyN1MXJgUxNtZv4Qi5M1p5m7aFmHo3AQXD\",\"publicKeyBase58\":\"Fwwr3ccA6UEWFWWpd7X7Xo1vEqSDw8Zj56fKw1q2FBjq\"}],\"capabilityDelegation\":[\"did:web:kyledenhartog.com#signingKey\"],\"capabilityInvocation\":[\"did:web:kyledenhartog.com#signingKey\"],\"keyAgreement\":[\"did:web:kyledenhartog.com#handshakeKey\",\"/pathHandshakeKey\"],\"service\":[{\"id\":\"did:web:kyledenhartog.com#dogPicService\",\"type\":\"DogPicService\",\"serviceEndpoint\":\"https://i.imgur.com\"}]}",
+            "didDocumentMetadata": {},
+            "didResolutionMetadata": {
+                "contentType": "application/did+ld+json"
+            }
+        },
+        "application/did+json": {
+            "didDocumentDataModel": {
+                "representationSpecificEntries": {}
+            },
+            "representation": "{\"@context\":[\"https://www.w3.org/ns/did/v1\",\"https://kyledenhartog/context/doggoservice\",\"https://www.w3id.org/security/suites/ed25519-2018/v1\",\"https://www.w3id.org/security/suites/x25519-2019/v1\"],\"id\":\"did:web:kyledenhartog.com\",\"verificationMethod\":[{\"id\":\"#signingKey\",\"type\":\"Ed25519VerificationKey2018\",\"controller\":\"did:web:kyledenhartog.com\",\"publicKeyBase58\":\"AywtfWyMWRTokKnnwLChyCDMM32sbLzcGFxuuxKtwmxH\"},{\"id\":\"did:web:kyledenhartog.com#handshakeKey\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:web:kyledenhartog.com\",\"publicKeyBase58\":\"trJuKT83nv2FruwDkmMD5945R1syU5sCDiLm4kr2mTj\"},{\"id\":\"/pathHandshakeKey\",\"type\":\"X25519KeyAgreementKey2019\",\"controller\":\"did:key:z6MkuQCtdrrbS1iyN1MXJgUxNtZv4Qi5M1p5m7aFmHo3AQXD\",\"publicKeyBase58\":\"5YLjenFRbMKCHV9HsFWhYbmxUnVnuEQxREwYvmRcLpX7\"}],\"authentication\":[\"did:web:kyledenhartog.com#signingKey\"],\"assertionMethod\":[\"did:web:kyledenhartog.com#signingKey\",{\"id\":\"did:web:kyledenhartog.com/fullyQualifiedPathSigningKey\",\"type\":\"Ed25519VerificationKey2018\",\"controller\":\"did:key:z6MkuQCtdrrbS1iyN1MXJgUxNtZv4Qi5M1p5m7aFmHo3AQXD\",\"publicKeyBase58\":\"Fwwr3ccA6UEWFWWpd7X7Xo1vEqSDw8Zj56fKw1q2FBjq\"}],\"capabilityDelegation\":[\"did:web:kyledenhartog.com#signingKey\"],\"capabilityInvocation\":[\"did:web:kyledenhartog.com#signingKey\"],\"keyAgreement\":[\"did:web:kyledenhartog.com#handshakeKey\",\"/pathHandshakeKey\"],\"service\":[{\"id\":\"did:web:kyledenhartog.com#dogPicService\",\"type\":\"DogPicService\",\"serviceEndpoint\":\"https://i.imgur.com\"}]}",
+            "didDocumentMetadata": {},
+            "didResolutionMetadata": {
+                "contentType": "application/did+json"
+            }
+        }
+    },
+    "dids": ["did:web:did.actor:healthcare:doctor:robert", "did:web:did.actor:mike", "did:web:kyledenhartog.com"]
 }


### PR DESCRIPTION
Updates our implementations to add support for JSON and move the didParameters into our dereferencer report instead of the did syntax report. As far as I can tell this should address all of the JSON features now and should make all of the syntax tests pass for every query parameter even though our dereferencer doesn't support every query parameter.