### PR TITLE
Add conformance section

### DIFF
--- a/packages/did-core-test-server/report/report-template.html
+++ b/packages/did-core-test-server/report/report-template.html
@@ -92,7 +92,7 @@
         W3C DID Working Group.
       </p>
     </section>
-
+    <section id="conformance"></section>
     <section id="introduction">
       <h2>Introduction</h2>
       <p>


### PR DESCRIPTION
This PR attempts to address a ReSpec warning about a missing conformance section.

Signed-off-by: Brent Zundel <brent.zundel@gmail.com>