### PR TITLE
fix integer vs double test

### DIFF
--- a/packages/did-core-test-server/suites/did-production/did-json-production.js
+++ b/packages/did-core-test-server/suites/did-production/did-json-production.js
@@ -44,7 +44,7 @@ const generateJsonProductionTests = (
             expect(produce(value)).toBe(true);
           });
         } else if(typeof value === 'number') {
-          if(!Number.isInteger(value)) {
+          if(Number.isInteger(value)) {
             it('6.2.1 JSON Production - integer: A JSON Number without a ' +
               'decimal or fractional component.', () => {
               expect(produce(value)).toBe(true);


### PR DESCRIPTION
I think the if statement for integer vs double test is wrong

example: 
[did-web-mattr.json](https://github.com/w3c/did-test-suite/blob/829312ab92badc94ce68e29e043151326140345d/packages/did-core-test-server/suites/implementations/did-web-mattr.json#L67) provides: `"ranking": 4.5`

* current result: [integer test passes](https://w3c.github.io/did-test-suite/#T43)
* expected result: [double test should pass](https://w3c.github.io/did-test-suite/#T42)
