### PR TITLE
Implement DID v1.1 tests.

### DIFF
--- a/packages/did-core-test-server/suites/did-production/default.js
+++ b/packages/did-core-test-server/suites/did-production/default.js
@@ -1,11 +1,11 @@
+const { addDidv11Implementations } = require("../utils");
 const brokenFixtures = process.env.DID_WG_INCLUDE_BREAKING ? [
   require('../implementations/did-unisot.json'),
 ] : []
 
-
 module.exports = {
   name: 'did-production',
-  didMethods: [
+  didMethods: addDidv11Implementations([
     require('../implementations/did-example-didwg.json'),
     require('../implementations/did-is.json'),
     require('../implementations/did-key-2018-db.json'),
@@ -47,5 +47,5 @@ module.exports = {
     require('../implementations/did-webvh-dif-py.json'),
     require('../implementations/did-webvh-dif-ts.json'),
     ...brokenFixtures
-  ],
+  ]),
 };

--- a/packages/did-core-test-server/suites/did-production/did-jsonld-production.js
+++ b/packages/did-core-test-server/suites/did-production/did-jsonld-production.js
@@ -19,7 +19,7 @@ const generateJsonldProductionTests = (
       expect(didDocument).toHaveProperty('@context');
   });
 
-  it('6.3.1 JSON-LD Production - The serialized value of @context ' +
+  it('6.3.1 JSON-LD Production (DID v1.0) - The serialized value of @context ' +
     'MUST be the JSON String https://www.w3.org/ns/did/v1, or a JSON ' +
     'Array where the first item is the JSON String ' +
     'https://www.w3.org/ns/did/v1 and the subsequent items are serialized ' +
@@ -30,6 +30,24 @@ const generateJsonldProductionTests = (
         expect(context).toBe('https://www.w3.org/ns/did/v1');
       } else if(Array.isArray(context)) {
         expect(context[0]).toBe('https://www.w3.org/ns/did/v1');
+        reserializedContext = JSON.parse(JSON.stringify(context));
+        expect(context).toEqual(reserializedContext);
+      } else {
+        throw new Error('Invalid @context value '+ context);
+      }
+  });
+
+  it('6.3.1 JSON-LD Production (DID v1.1) - The serialized value of @context ' +
+    'MUST be the JSON String https://www.w3.org/ns/did/v1.1, or a JSON ' +
+    'Array where the first item is the JSON String ' +
+    'https://www.w3.org/ns/did/v1.1 and the subsequent items are serialized ' +
+    'according to the JSON representation production rules.', async () => {
+      const context = didDocument['@context'];
+
+      if(typeof context === 'string') {
+        expect(context).toBe('https://www.w3.org/ns/did/v1.1');
+      } else if(Array.isArray(context)) {
+        expect(context[0]).toBe('https://www.w3.org/ns/did/v1.1');
         reserializedContext = JSON.parse(JSON.stringify(context));
         expect(context).toEqual(reserializedContext);
       } else {

--- a/packages/did-core-test-server/suites/did-production/did-jsonld-production.js
+++ b/packages/did-core-test-server/suites/did-production/did-jsonld-production.js
@@ -19,35 +19,19 @@ const generateJsonldProductionTests = (
       expect(didDocument).toHaveProperty('@context');
   });
 
-  it('6.3.1 JSON-LD Production (DID v1.0) - The serialized value of @context ' +
-    'MUST be the JSON String https://www.w3.org/ns/did/v1, or a JSON ' +
+  it('6.3.1 JSON-LD Production - The serialized value of @context ' +
+    'MUST be the JSON String https://www.w3.org/ns/did/v1 (DID v1.0) or '+
+    'https://www.w3.org/ns/did/v1.1 (DID v1.1), or a JSON ' +
     'Array where the first item is the JSON String ' +
-    'https://www.w3.org/ns/did/v1 and the subsequent items are serialized ' +
+    'https://www.w3.org/ns/did/v1 or https://www.w3.org/ns/did/v1.1, '+
+    'and the subsequent items are serialized ' +
     'according to the JSON representation production rules.', async () => {
       const context = didDocument['@context'];
 
       if(typeof context === 'string') {
-        expect(context).toBe('https://www.w3.org/ns/did/v1');
+        expect(context).toMatch(/^https\:\/\/www.w3.org\/ns\/did\/v1|https\:\/\/www.w3.org\/ns\/did\/v1\.1$/);
       } else if(Array.isArray(context)) {
-        expect(context[0]).toBe('https://www.w3.org/ns/did/v1');
-        reserializedContext = JSON.parse(JSON.stringify(context));
-        expect(context).toEqual(reserializedContext);
-      } else {
-        throw new Error('Invalid @context value '+ context);
-      }
-  });
-
-  it('6.3.1 JSON-LD Production (DID v1.1) - The serialized value of @context ' +
-    'MUST be the JSON String https://www.w3.org/ns/did/v1.1, or a JSON ' +
-    'Array where the first item is the JSON String ' +
-    'https://www.w3.org/ns/did/v1.1 and the subsequent items are serialized ' +
-    'according to the JSON representation production rules.', async () => {
-      const context = didDocument['@context'];
-
-      if(typeof context === 'string') {
-        expect(context).toBe('https://www.w3.org/ns/did/v1.1');
-      } else if(Array.isArray(context)) {
-        expect(context[0]).toBe('https://www.w3.org/ns/did/v1.1');
+        expect(context[0]).toMatch(/^https\:\/\/www.w3.org\/ns\/did\/v1|https\:\/\/www.w3.org\/ns\/did\/v1\.1$/);
         reserializedContext = JSON.parse(JSON.stringify(context));
         expect(context).toEqual(reserializedContext);
       } else {

--- a/packages/did-core-test-server/suites/utils.js
+++ b/packages/did-core-test-server/suites/utils.js
@@ -126,7 +126,7 @@ function updateContextsToDidv11(obj) {
             newRepresentation['@context'][0] = 'https://www.w3.org/ns/did/v1.1';
         }
         obj['representation'] = JSON.stringify(newRepresentation);
-    }
+      }
     } else {
       if(typeof obj[key] === 'object' && obj[key] !== null) {
         updateContextsToDidv11(obj[key]);

--- a/packages/did-core-test-server/suites/utils.js
+++ b/packages/did-core-test-server/suites/utils.js
@@ -29,7 +29,7 @@ const isValidJwk = (jwk) => {
     jose.JWK.asKey(jwk);
     valid = true;
   } catch (error) {
-    // un comment to see JWKs that might 
+    // un comment to see JWKs that might
     // be valid but not yet
     // widely supported, like BLS 12381
     // console.warn('invalid jwk', jwk)
@@ -105,6 +105,52 @@ const isValidVerificationMethod = (vm) => {
   return true;
 }
 
+function updateContextsToDidv11(obj) {
+  if(typeof obj !== 'object' || obj === null) {
+    return;
+  }
+
+  for(const key in obj) {
+    if(key === '@context') {
+      if(obj['@context'][0] ===
+        'https://www.w3.org/ns/did/v1') {
+          obj['@context'][0] = 'https://www.w3.org/ns/did/v1.1';
+      }
+    }
+
+    if(key === 'representation') {
+      let newRepresentation = JSON.parse(obj['representation']);
+      if(newRepresentation['@context'] !== undefined) {
+        if(newRepresentation['@context'][0] ===
+          'https://www.w3.org/ns/did/v1') {
+            newRepresentation['@context'][0] = 'https://www.w3.org/ns/did/v1.1';
+        }
+        obj['representation'] = JSON.stringify(newRepresentation);
+    }
+    } else {
+      if(typeof obj[key] === 'object' && obj[key] !== null) {
+        updateContextsToDidv11(obj[key]);
+      }
+    }
+  }
+}
+
+const addDidv11Implementations = (implementations) => {
+  const allImplementations = [];
+
+  implementations.forEach((suiteConfig) => {
+    v10SuiteConfig = suiteConfig;
+    v11SuiteConfig = JSON.parse(JSON.stringify(suiteConfig));
+    v10SuiteConfig.implementation += ' (DID v1.0)';
+    v11SuiteConfig.implementation += ' (DID v1.1)';
+    updateContextsToDidv11(v11SuiteConfig);
+    allImplementations.push(v10SuiteConfig);
+    allImplementations.push(v11SuiteConfig);
+  })
+
+  return allImplementations;
+}
+
 module.exports = {
   getAbsoluteDIDURL,
   getQueryParamValueFromDidUri,
@@ -117,5 +163,6 @@ module.exports = {
   isXmlDatetime,
   isAsciiString,
   getQueryParamValueFromDidUri,
-  isValidVerificationMethod
+  isValidVerificationMethod,
+  addDidv11Implementations
 };

--- a/packages/did-core-test-server/suites/utils.js
+++ b/packages/did-core-test-server/suites/utils.js
@@ -140,7 +140,7 @@ const addDidv11Implementations = (implementations) => {
 
   implementations.forEach((suiteConfig) => {
     v10SuiteConfig = suiteConfig;
-    v11SuiteConfig = JSON.parse(JSON.stringify(suiteConfig));
+    v11SuiteConfig = structuredClone(suiteConfig);
     v10SuiteConfig.implementation += ' (DID v1.0)';
     v11SuiteConfig.implementation += ' (DID v1.1)';
     updateContextsToDidv11(v11SuiteConfig);


### PR DESCRIPTION
This PR is an attempt to upgrade the DID test suite to support v1.1 (which uses a separate context entry). The purpose here is to effectively duplicate all existing implementations, upgrading them to support v1.0 and v1.1 DID Documents. This PR proves that approach to be viable. 

We might also choose to do JSON-LD canonicalization on the v1.1 documents to ensure they canonicalize to the same values as v1.0.